### PR TITLE
Camera image: adjustment of levels + box overlay with dimensions (in um)

### DIFF
--- a/mesoSPIM/config/demo_config.py
+++ b/mesoSPIM/config/demo_config.py
@@ -11,7 +11,7 @@ with real hardware one-by-one. Make sure to rename your new configuration file t
 '''
 Dark mode: Renders the UI dark
 '''
-dark_mode = True
+dark_mode = False
 
 '''
 Waveform output for Galvos, ETLs etc.

--- a/mesoSPIM/config/demo_config.py
+++ b/mesoSPIM/config/demo_config.py
@@ -11,7 +11,7 @@ with real hardware one-by-one. Make sure to rename your new configuration file t
 '''
 Dark mode: Renders the UI dark
 '''
-dark_mode = False
+dark_mode = True
 
 '''
 Waveform output for Galvos, ETLs etc.

--- a/mesoSPIM/gui/mesoSPIM_CameraWindow.ui
+++ b/mesoSPIM/gui/mesoSPIM_CameraWindow.ui
@@ -6,8 +6,8 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>1114</width>
-    <height>1015</height>
+    <width>1200</width>
+    <height>1080</height>
    </rect>
   </property>
   <property name="windowTitle">
@@ -16,6 +16,53 @@
   <layout class="QGridLayout" name="gridLayout">
    <item row="0" column="0">
     <widget class="ImageView" name="graphicsView"/>
+   </item>
+   <item row="1" column="0">
+    <layout class="QHBoxLayout" name="horizontalLayout_2">
+     <item>
+      <widget class="QPushButton" name="adjustLevelsButton">
+       <property name="text">
+        <string>Adjust levels</string>
+       </property>
+      </widget>
+     </item>
+     <item>
+      <widget class="QComboBox" name="overlayCombo">
+       <property name="minimumSize">
+        <size>
+         <width>100</width>
+         <height>0</height>
+        </size>
+       </property>
+       <property name="toolTip">
+        <string>Image overlay</string>
+       </property>
+       <item>
+        <property name="text">
+         <string>Center cross</string>
+        </property>
+       </item>
+       <item>
+        <property name="text">
+         <string>Resizable box</string>
+        </property>
+       </item>
+      </widget>
+     </item>
+     <item>
+      <spacer name="horizontalSpacer">
+       <property name="orientation">
+        <enum>Qt::Horizontal</enum>
+       </property>
+       <property name="sizeHint" stdset="0">
+        <size>
+         <width>40</width>
+         <height>20</height>
+        </size>
+       </property>
+      </spacer>
+     </item>
+    </layout>
    </item>
   </layout>
  </widget>

--- a/mesoSPIM/gui/mesoSPIM_CameraWindow.ui
+++ b/mesoSPIM/gui/mesoSPIM_CameraWindow.ui
@@ -44,7 +44,7 @@
        </item>
        <item>
         <property name="text">
-         <string>Resizable box</string>
+         <string>Box roi</string>
         </property>
        </item>
       </widget>

--- a/mesoSPIM/gui/mesoSPIM_CameraWindow.ui
+++ b/mesoSPIM/gui/mesoSPIM_CameraWindow.ui
@@ -30,7 +30,7 @@
       <widget class="QComboBox" name="overlayCombo">
        <property name="minimumSize">
         <size>
-         <width>100</width>
+         <width>110</width>
          <height>0</height>
         </size>
        </property>
@@ -39,7 +39,7 @@
        </property>
        <item>
         <property name="text">
-         <string>Center cross</string>
+         <string>Overlay: none</string>
         </property>
        </item>
        <item>

--- a/mesoSPIM/src/mesoSPIM_CameraWindow.py
+++ b/mesoSPIM/src/mesoSPIM_CameraWindow.py
@@ -53,7 +53,7 @@ class mesoSPIM_CameraWindow(QtWidgets.QWidget):
         self.x_image_width = self.cfg.camera_parameters['y_pixels']
 
         ''' Initialize crosshairs '''
-        self.crosspen = pg.mkPen({'color': "g", 'width': 1})
+        self.crosspen = pg.mkPen({'color': "r", 'width': 1})
         self.vLine = pg.InfiniteLine(pos=self.x_image_width/2, angle=90, movable=False, pen=self.crosspen)
         self.hLine = pg.InfiniteLine(pos=self.y_image_width/2, angle=0, movable=False, pen=self.crosspen)
         self.graphicsView.addItem(self.vLine, ignoreBounds=True)

--- a/mesoSPIM/src/mesoSPIM_CameraWindow.py
+++ b/mesoSPIM/src/mesoSPIM_CameraWindow.py
@@ -61,7 +61,7 @@ class mesoSPIM_CameraWindow(QtWidgets.QWidget):
 
         # Create overlay ROIs
         self.roi_box = pg.RectROI((self.x_image_width//2 - 50, self.y_image_width//2 - 50), (100, 100))
-        self.roi_box_w_text, self.roi_box_h_text = pg.TextItem(color='g'), pg.TextItem(color='r', angle=90)
+        self.roi_box_w_text, self.roi_box_h_text = pg.TextItem(color='r'), pg.TextItem(color='r', angle=90)
         self.roi_list = [self.roi_box, self.roi_box_w_text, self.roi_box_h_text]
 
         # Set up CameraWindow signals

--- a/mesoSPIM/src/mesoSPIM_CameraWindow.py
+++ b/mesoSPIM/src/mesoSPIM_CameraWindow.py
@@ -14,6 +14,8 @@ from PyQt5.uic import loadUi
 import pyqtgraph as pg
 
 class mesoSPIM_CameraWindow(QtWidgets.QWidget):
+    sig_change_overlay = QtCore.pyqtSignal(dict)
+
     def __init__(self, parent=None):
         super().__init__()
 
@@ -22,7 +24,7 @@ class mesoSPIM_CameraWindow(QtWidgets.QWidget):
 
         ''' Change the PyQtGraph-Options in White Mode'''
         pg.setConfigOptions(imageAxisOrder='row-major')
-        if self.cfg.dark_mode == False:
+        if not self.cfg.dark_mode:
             pg.setConfigOptions(foreground='k')
             pg.setConfigOptions(background='w')
         else:
@@ -37,8 +39,6 @@ class mesoSPIM_CameraWindow(QtWidgets.QWidget):
         else:
             loadUi('gui/mesoSPIM_CameraWindow.ui', self)
         self.setWindowTitle('mesoSPIM-Control: Camera Window')
-
-
 
         ''' Set histogram Range '''
         self.graphicsView.setLevels(100,4000)
@@ -61,13 +61,16 @@ class mesoSPIM_CameraWindow(QtWidgets.QWidget):
         '''
 
         ''' Initialize crosshairs '''
-        self.crosspen = pg.mkPen({'color': "r", 'width': 1})
+        self.crosspen = pg.mkPen({'color': "g", 'width': 1})
         self.vLine = pg.InfiniteLine(pos=self.x_image_width/2, angle=90, movable=False, pen=self.crosspen)
         self.hLine = pg.InfiniteLine(pos=self.y_image_width/2, angle=0, movable=False, pen=self.crosspen)
         self.graphicsView.addItem(self.vLine, ignoreBounds=True)
         self.graphicsView.addItem(self.hLine, ignoreBounds=True)
         # print(self.vLine.getXPos())
         # print(self.hLine.getYPos())
+
+        # Set up CameraWindow signals
+        self.adjustLevelsButton.clicked.connect(self.graphicsView.autoLevels)
 
         logger.info('Thread ID at Startup: '+str(int(QtCore.QThread.currentThreadId())))
 

--- a/mesoSPIM/src/mesoSPIM_CameraWindow.py
+++ b/mesoSPIM/src/mesoSPIM_CameraWindow.py
@@ -61,7 +61,7 @@ class mesoSPIM_CameraWindow(QtWidgets.QWidget):
 
         # Create overlay ROIs
         self.roi_box = pg.RectROI((self.x_image_width//2 - 50, self.y_image_width//2 - 50), (100, 100))
-        self.roi_box_w_text, self.roi_box_h_text = pg.TextItem(color='g'), pg.TextItem(color='g', angle=90)
+        self.roi_box_w_text, self.roi_box_h_text = pg.TextItem(color='g'), pg.TextItem(color='r', angle=90)
         self.roi_list = [self.roi_box, self.roi_box_w_text, self.roi_box_h_text]
 
         # Set up CameraWindow signals


### PR DESCRIPTION
Hi, everyone,
I implemented two convenience features in the `Camera Window` which I wanted for a long time:
- a button `Adjust levels` in the bottom left corner to adjust the image intensity between min and max. This allows quick intensity adjustment without fiddling with histogram handles.
- a drop-down list that allows overlaying a `Box ROI` which displays it's size in um (according to the current zoom). This allows measuring the approximate sample/feature dimensions during the experiment.

I hope you find them as useful as I do!
 
![image](https://user-images.githubusercontent.com/10835134/99723788-edf90f80-2ab2-11eb-9f40-9f29872d5b59.png)

