### PR TITLE
fix - dynamixel init with config baudrate

### DIFF
--- a/mesoSPIM/src/mesoSPIM_Serial.py
+++ b/mesoSPIM/src/mesoSPIM_Serial.py
@@ -54,7 +54,7 @@ class mesoSPIM_Serial(QtCore.QObject):
 
         ''' Attaching the zoom '''
         if self.cfg.zoom_parameters['zoom_type'] == 'Dynamixel':
-            self.zoom = DynamixelZoom(self.cfg.zoomdict, self.cfg.zoom_parameters['COMport'],self.cfg.zoom_parameters['servo_id'])
+            self.zoom = DynamixelZoom(self.cfg.zoomdict, self.cfg.zoom_parameters['COMport'], self.cfg.zoom_parameters['servo_id'], self.cfg.zomm_parameters['baudrate'])
         elif self.cfg.zoom_parameters['zoom_type'] == 'DemoZoom':
             self.zoom = DemoZoom(self.cfg.zoomdict)
 


### PR DESCRIPTION
Config file parameters should always be used first.