### PR TITLE
Do not write duplicate data z_stepsize and z_planes data in metadata.

### DIFF
--- a/mesoSPIM/src/mesoSPIM_ImageWriter.py
+++ b/mesoSPIM/src/mesoSPIM_ImageWriter.py
@@ -281,8 +281,6 @@ class mesoSPIM_ImageWriter(QtCore.QObject):
             self.metadata_file = open(metadata_path, 'w')
 
         self.write_line(self.metadata_file, 'Metadata for file', path)
-        self.write_line(self.metadata_file, 'z_stepsize', acq['z_step'])
-        self.write_line(self.metadata_file, 'z_planes', acq['planes'])
         self.write_line(self.metadata_file)
         # self.write_line(file, 'COMMENTS')
         # self.write_line(file, 'Comment: ', acq(['comment']))

--- a/mesoSPIM/src/mesoSPIM_ImageWriter.py
+++ b/mesoSPIM/src/mesoSPIM_ImageWriter.py
@@ -352,4 +352,4 @@ class mesoSPIM_ImageWriter(QtCore.QObject):
             self.write_line(file, 'Started taking images', kwargs.get('img_start'))
             self.write_line(file, 'Stopped taking images', kwargs.get('img_end'))
             self.write_line(file, 'Stopped stack', kwargs.get('acq_end'))
-            self.write_line(file, 'Frame rate:', str(acq.get_image_count()/kwargs.get('img_total_time')))
+            self.write_line(file, 'Frame rate', str(acq.get_image_count()/kwargs.get('img_total_time')))


### PR DESCRIPTION
I don't know if there was a reason for this, but there are two duplicate lines being written to meta-data files. Since it can potentially cause confusion reading back these data, I suggest removing them. 
I add a second commit that removes the `:` in `[Frame rate:]`, as no other keys have this. 