### PR TITLE
Disable buttons and spinboxes for the opposite light-sheet during ETL parameter optimization

### DIFF
--- a/mesoSPIM/src/mesoSPIM_MainWindow.py
+++ b/mesoSPIM/src/mesoSPIM_MainWindow.py
@@ -422,6 +422,8 @@ class mesoSPIM_MainWindow(QtWidgets.QMainWindow):
         self.SnapFolderIndicator.setText(self.state['snap_folder'])
         self.ETLconfigIndicator.setText(self.state['ETL_cfg_file'])
 
+        self.ShutterComboBox.currentIndexChanged.connect(self.set_shutter)
+
         self.widget_to_state_parameter_assignment=(
             (self.FilterComboBox, 'filter',1),
             (self.FilterComboBox, 'filter',1),
@@ -518,6 +520,30 @@ class mesoSPIM_MainWindow(QtWidgets.QMainWindow):
         self.sig_state_request.emit({'intensity': value})
         self.LaserIntensitySlider.setValue(value)
         self.LaserIntensitySpinBox.setValue(value)
+
+    def set_shutter(self):
+        ''' Disables controls for the opposite ETL to avoid overriding parameters '''
+        if self.ShutterComboBox.currentText() == 'Left':
+            self.LeftETLOffsetSpinBox.setEnabled(True)
+            self.LeftETLAmplitudeSpinBox.setEnabled(True)
+            self.ZeroLeftETLButton.setEnabled(True)
+            self.RightETLOffsetSpinBox.setEnabled(False)
+            self.RightETLAmplitudeSpinBox.setEnabled(False)
+            self.ZeroRightETLButton.setEnabled(False)
+        elif self.ShutterComboBox.currentText() == 'Right':
+            self.RightETLOffsetSpinBox.setEnabled(True)
+            self.RightETLAmplitudeSpinBox.setEnabled(True)
+            self.ZeroRightETLButton.setEnabled(True)
+            self.LeftETLOffsetSpinBox.setEnabled(False)
+            self.LeftETLAmplitudeSpinBox.setEnabled(False)
+            self.ZeroLeftETLButton.setEnabled(False)
+        else: # In case of "Both" (or if something completely different is in the config file)
+            self.RightETLOffsetSpinBox.setEnabled(True)
+            self.RightETLAmplitudeSpinBox.setEnabled(True)
+            self.ZeroRightETLButton.setEnabled(True)
+            self.LeftETLOffsetSpinBox.setEnabled(True)
+            self.LeftETLAmplitudeSpinBox.setEnabled(True)
+            self.ZeroLeftETLButton.setEnabled(True)
 
     def connect_widget_to_state_parameter(self, widget, state_parameter, conversion_factor):
         '''
@@ -742,16 +768,40 @@ class mesoSPIM_MainWindow(QtWidgets.QMainWindow):
         if self.ZeroLeftETLButton.isChecked():
             self.ETL_L_amp_backup = self.LeftETLAmplitudeSpinBox.value()
             self.LeftETLAmplitudeSpinBox.setValue(0)
+            self.LeftETLAmplitudeSpinBox.setEnabled(False)
+            self.SaveETLParametersButton.setEnabled(False)
+            if self.ShutterComboBox.currentText() == 'Both':
+                self.RightETLOffsetSpinBox.setEnabled(False)
+                self.RightETLAmplitudeSpinBox.setEnabled(False)
+                self.ZeroRightETLButton.setEnabled(False)
         else:
             self.LeftETLAmplitudeSpinBox.setValue(self.ETL_L_amp_backup)
+            self.LeftETLAmplitudeSpinBox.setEnabled(True)
+            self.SaveETLParametersButton.setEnabled(True)
+            if self.ShutterComboBox.currentText() == 'Both':
+                self.RightETLOffsetSpinBox.setEnabled(True)
+                self.RightETLAmplitudeSpinBox.setEnabled(True)
+                self.ZeroRightETLButton.setEnabled(True)
 
     def zero_right_etl(self):
         ''' Zeros the amplitude of the right ETL for faster alignment '''
         if self.ZeroRightETLButton.isChecked():
             self.ETL_R_amp_backup = self.RightETLAmplitudeSpinBox.value()
             self.RightETLAmplitudeSpinBox.setValue(0)
+            self.RightETLAmplitudeSpinBox.setEnabled(False)
+            self.SaveETLParametersButton.setEnabled(False)
+            if self.ShutterComboBox.currentText() == 'Both':
+                self.LeftETLOffsetSpinBox.setEnabled(False)
+                self.LeftETLAmplitudeSpinBox.setEnabled(False)
+                self.ZeroLeftETLButton.setEnabled(False)
         else:
             self.RightETLAmplitudeSpinBox.setValue(self.ETL_R_amp_backup)
+            self.RightETLAmplitudeSpinBox.setEnabled(True)
+            self.SaveETLParametersButton.setEnabled(True)
+            if self.ShutterComboBox.currentText() == 'Both':
+                self.LeftETLOffsetSpinBox.setEnabled(True)
+                self.LeftETLAmplitudeSpinBox.setEnabled(True)
+                self.ZeroLeftETLButton.setEnabled(True)
 
     def zero_galvo_amp(self):
         '''Set the amplitude of both galvos to zero, or back to where it was, depending on button state'''

--- a/mesoSPIM/src/mesoSPIM_MainWindow.py
+++ b/mesoSPIM/src/mesoSPIM_MainWindow.py
@@ -770,6 +770,7 @@ class mesoSPIM_MainWindow(QtWidgets.QMainWindow):
             self.LeftETLAmplitudeSpinBox.setValue(0)
             self.LeftETLAmplitudeSpinBox.setEnabled(False)
             self.SaveETLParametersButton.setEnabled(False)
+            self.ChooseETLcfgButton.setEnabled(False)
             if self.ShutterComboBox.currentText() == 'Both':
                 self.RightETLOffsetSpinBox.setEnabled(False)
                 self.RightETLAmplitudeSpinBox.setEnabled(False)
@@ -778,6 +779,7 @@ class mesoSPIM_MainWindow(QtWidgets.QMainWindow):
             self.LeftETLAmplitudeSpinBox.setValue(self.ETL_L_amp_backup)
             self.LeftETLAmplitudeSpinBox.setEnabled(True)
             self.SaveETLParametersButton.setEnabled(True)
+            self.ChooseETLcfgButton.setEnabled(True)
             if self.ShutterComboBox.currentText() == 'Both':
                 self.RightETLOffsetSpinBox.setEnabled(True)
                 self.RightETLAmplitudeSpinBox.setEnabled(True)
@@ -790,6 +792,7 @@ class mesoSPIM_MainWindow(QtWidgets.QMainWindow):
             self.RightETLAmplitudeSpinBox.setValue(0)
             self.RightETLAmplitudeSpinBox.setEnabled(False)
             self.SaveETLParametersButton.setEnabled(False)
+            self.ChooseETLcfgButton.setEnabled(False)
             if self.ShutterComboBox.currentText() == 'Both':
                 self.LeftETLOffsetSpinBox.setEnabled(False)
                 self.LeftETLAmplitudeSpinBox.setEnabled(False)
@@ -798,6 +801,7 @@ class mesoSPIM_MainWindow(QtWidgets.QMainWindow):
             self.RightETLAmplitudeSpinBox.setValue(self.ETL_R_amp_backup)
             self.RightETLAmplitudeSpinBox.setEnabled(True)
             self.SaveETLParametersButton.setEnabled(True)
+            self.ChooseETLcfgButton.setEnabled(True)
             if self.ShutterComboBox.currentText() == 'Both':
                 self.LeftETLOffsetSpinBox.setEnabled(True)
                 self.LeftETLAmplitudeSpinBox.setEnabled(True)


### PR DESCRIPTION
When training new mesoSPIM users, I noted that they often start by:
1) Trying to optimize ETL parameters for the opposite light-sheet and don't realize that the image is not changing
2) Changing the ETL amplitude after toggling the AmpL/R=0 buttons
3) Overwriting the ETL amplitude in the config file after toggling the AmpL/R=0 buttons by hitting the save button at the wrong time.

With experience, they stop doing this - but this is highly confusing for beginners.  To avoid this source of frustration, this commit adds code to disable the relevant ETL parameter buttons for the opposite light-sheet. I've also tried to make sure that this works when a mesoSPIM is configured to allow both illumination directions.