### PR TITLE
Bugfix to get the ZWO 2" 7-position filterwheel running

### DIFF
--- a/mesoSPIM/src/devices/filter_wheels/ZWO_EFW/pyzwoefw.py
+++ b/mesoSPIM/src/devices/filter_wheels/ZWO_EFW/pyzwoefw.py
@@ -130,8 +130,8 @@ class EFW(object):
         for ID in self.IDs: 
             self.Open(ID)
             self.slotNums[ID] = (self.GetProperty(ID)['slotNum'])
-            self.SetDirection(ID, True)
             self.SetPosition(ID, 0)            
+            #self.SetDirection(ID, True)
 
     def GetNum(self): #ok
         return self.dll.EFWGetNum()


### PR DESCRIPTION
The ZWO 2" 7-position filterwheel will not run unless `self.SetDirection(ID, True)` is called after `self.SetPosition(ID, 0)` (It gives off a "General error" otherwise). Trying different versions of `EFW_filter.dll` didn't help. Also, unless I'm missing something, `self.SetDirection(ID, True)` is not strictly necessary and leads to longer filter change delays as the filterwheel rotates in one direction only. 