### PR TITLE
If shutterswitch = 'False' no signals to shutter_left line.

### DIFF
--- a/mesoSPIM/src/mesoSPIM_Core.py
+++ b/mesoSPIM/src/mesoSPIM_Core.py
@@ -452,7 +452,7 @@ class mesoSPIM_Core(QtCore.QObject):
                 self.shutter_right.open()
         elif shutterconfig == 'Left':
             if self.shutterswitch is False:
-                self.shutter_left.open()
+              #  self.shutter_left.open()
                 self.shutter_right.close()
             else:
                 self.shutter_left.open() # open the general shutter
@@ -461,7 +461,7 @@ class mesoSPIM_Core(QtCore.QObject):
         elif shutterconfig == 'Right':
             if self.shutterswitch is False:
                 self.shutter_right.open()
-                self.shutter_left.close()
+                # self.shutter_left.close()
             else:
                 self.shutter_left.open() # open the general shutter
                 self.shutter_right.open() # set side-switch to true


### PR DESCRIPTION
Line 455 is the key "silencing" of shutter_left to enable imaging with the left arm in my setup (including hardware connections and config file), I submit as I see you've kept some of the other commented out lines.  