### PR TITLE
Add optional remote scripting server (Tools -> Remote Scripting...)

### DIFF
--- a/mesoSPIM/scripts/remote_scripting_full_test.py
+++ b/mesoSPIM/scripts/remote_scripting_full_test.py
@@ -1,0 +1,1121 @@
+"""Full demo-mode remote-scripting test client for mesoSPIM.
+
+Run this from any Python environment that should control mesoSPIM, while the
+mesoSPIM GUI is running in demo mode and Tools -> Remote Scripting... is
+started.
+
+The test talks to the remote scripting TCP server and executes small Python
+snippets in the live mesoSPIM Core context. The default profile is the full demo
+profile: it changes controls, camera settings, waveform/ETL parameters, stage
+positions, shutters, zoom, and runs a no-write snap, then restores values where
+possible.
+
+Example:
+    python mesoSPIM/scripts/remote_scripting_full_test.py --token YOUR_TOKEN
+
+This script is intended for demo mode. It refuses to run against a non-demo stage
+unless --allow-non-demo is provided.
+"""
+
+from __future__ import annotations
+
+import argparse
+import getpass
+import json
+import os
+import socket
+import sys
+import textwrap
+import time
+from pathlib import Path
+
+
+ENCODING = "utf-8"
+RESULT_PREFIX = "__MESOSPIM_REMOTE_TEST_RESULT__ "
+SHOW_REMOTE_OUTPUT = False
+
+
+class RemoteScriptingError(RuntimeError):
+    pass
+
+
+class RemoteScriptingClient:
+    def __init__(self, host: str, port: int, token: str | None, timeout: float):
+        self.host = host
+        self.port = port
+        self.token = token
+        self.timeout = timeout
+        self.sock: socket.socket | None = None
+
+    def __enter__(self) -> "RemoteScriptingClient":
+        self.sock = socket.create_connection((self.host, self.port), timeout=self.timeout)
+        if self.token is not None:
+            self.sock.sendall(self._frame(self.token))
+            reply = self._read_frame()
+            if reply != "OK":
+                raise RemoteScriptingError(f"authentication failed: {reply!r}")
+        return self
+
+    def __exit__(self, exc_type, exc, tb) -> None:
+        if self.sock is not None:
+            self.sock.close()
+            self.sock = None
+
+    @staticmethod
+    def _frame(text: str) -> bytes:
+        payload = text.encode(ENCODING)
+        return str(len(payload)).encode("ascii") + b"\n" + payload
+
+    def _read_frame(self) -> str:
+        if self.sock is None:
+            raise RemoteScriptingError("client is not connected")
+        header = b""
+        while not header.endswith(b"\n"):
+            chunk = self.sock.recv(1)
+            if not chunk:
+                raise RemoteScriptingError("socket closed while reading frame header")
+            header += chunk
+        try:
+            length = int(header[:-1])
+        except ValueError as exc:
+            raise RemoteScriptingError(f"invalid frame header: {header!r}") from exc
+
+        payload = b""
+        while len(payload) < length:
+            chunk = self.sock.recv(length - len(payload))
+            if not chunk:
+                raise RemoteScriptingError("socket closed while reading frame payload")
+            payload += chunk
+        return payload.decode(ENCODING, "replace")
+
+    def run_script(self, script: str) -> str:
+        if self.sock is None:
+            raise RemoteScriptingError("client is not connected")
+        self.sock.sendall(self._frame(script))
+        return self._read_frame()
+
+
+def _remote_wrapper(name: str, body: str) -> str:
+    indented_body = textwrap.indent(body.rstrip(), "    ")
+    return f"""
+import json
+import time
+import traceback
+
+from PyQt5 import QtCore, QtWidgets
+
+core = self
+__result = {{"ok": True, "name": {name!r}}}
+
+def __json_default(value):
+    try:
+        return str(value)
+    except Exception:
+        return "<unserializable>"
+
+def __pump(ms=100):
+    deadline = time.time() + (ms / 1000.0)
+    while time.time() < deadline:
+        QtWidgets.QApplication.processEvents(QtCore.QEventLoop.AllEvents, 20)
+        time.sleep(0.01)
+
+try:
+{indented_body}
+except Exception:
+    __result["ok"] = False
+    __result["error"] = traceback.format_exc()
+
+print({RESULT_PREFIX!r} + json.dumps(__result, default=__json_default, sort_keys=True))
+"""
+
+
+def parse_remote_result(reply: str) -> dict:
+    for line in reversed(reply.splitlines()):
+        if line.startswith(RESULT_PREFIX):
+            return json.loads(line[len(RESULT_PREFIX) :])
+    raise RemoteScriptingError(
+        "remote script did not emit a structured result; reply was:\n" + reply
+    )
+
+
+def run_remote_json(client: RemoteScriptingClient, name: str, body: str, raw_dir: Path | None) -> dict:
+    reply = client.run_script(_remote_wrapper(name, body))
+    if raw_dir is not None:
+        raw_dir.mkdir(parents=True, exist_ok=True)
+        safe_name = "".join(ch if ch.isalnum() or ch in "._-" else "_" for ch in name)
+        (raw_dir / f"{safe_name}.reply.txt").write_text(reply, encoding=ENCODING)
+    if SHOW_REMOTE_OUTPUT:
+        remote_output = "\n".join(
+            line for line in reply.splitlines() if not line.startswith(RESULT_PREFIX)
+        ).strip()
+        if remote_output:
+            print("  Remote stdout/stderr:")
+            print(textwrap.indent(remote_output, "    "))
+    result = parse_remote_result(reply)
+    if not result.get("ok"):
+        raise RemoteScriptingError(result.get("error", "remote script failed"))
+    return result
+
+
+def choose_next(values: list, current):
+    if not values:
+        return current
+    if current in values and len(values) > 1:
+        return values[(values.index(current) + 1) % len(values)]
+    return values[0]
+
+
+def print_result(status: str, name: str, detail: str = "") -> None:
+    suffix = f" - {detail}" if detail else ""
+    print(f"[{status}] {name}{suffix}")
+
+
+def short_value(value, limit: int = 64) -> str:
+    if isinstance(value, (dict, list, tuple)):
+        text = json.dumps(value, sort_keys=True)
+    else:
+        text = str(value)
+    if len(text) > limit:
+        return text[: limit - 3] + "..."
+    return text
+
+
+def print_kv(label: str, value) -> None:
+    print(f"  {label:<24} {short_value(value, 96)}")
+
+
+def print_change_table(result: dict, keys: list[str] | None = None, *, limit: int | None = None) -> None:
+    before = result.get("before", {})
+    target = result.get("target", {})
+    after = result.get("after", {})
+    restored = result.get("restored", {})
+    if keys is None:
+        keys = sorted(set(before) | set(target) | set(after) | set(restored))
+    if limit is not None:
+        keys = keys[:limit]
+    print("  Changes:")
+    print("    key                                before -> target -> after -> restored")
+    for key in keys:
+        values = [
+            short_value(before.get(key, "")),
+            short_value(target.get(key, "")),
+            short_value(after.get(key, "")),
+            short_value(restored.get(key, "")),
+        ]
+        print(f"    {key:<34} {values[0]} -> {values[1]} -> {values[2]} -> {values[3]}")
+
+
+def print_named_change_table(result: dict, columns: list[tuple[str, str]], keys: list[str]) -> None:
+    print("  Changes:")
+    header = " -> ".join(label for label, _ in columns)
+    print(f"    {'key':<34} {header}")
+    for key in keys:
+        values = []
+        for _, source_key in columns:
+            source = result.get(source_key, {})
+            values.append(short_value(source.get(key, "")))
+        print(f"    {key:<34} {' -> '.join(values)}")
+
+
+def print_position(label: str, position: dict) -> None:
+    ordered = ["x_pos", "y_pos", "z_pos", "f_pos", "theta_pos"]
+    parts = [f"{key}={position.get(key)}" for key in ordered if key in position]
+    print(f"  {label:<24} " + ", ".join(parts))
+
+
+def print_test_details(name: str, result: dict) -> None:
+    if name == "probe":
+        state = result.get("state", {})
+        print_kv("Core state", state.get("state"))
+        print_position("Position", state.get("position", {}))
+        print_kv("Stage class", result.get("stage_class"))
+        config = result.get("config", {})
+        print_kv("Lasers", config.get("lasers", []))
+        print_kv("Filters", config.get("filters", []))
+        print_kv("Shutters", config.get("shutters", []))
+        print_kv("Zooms", config.get("zooms", []))
+    elif name == "status/control widgets":
+        print_change_table(result, ["laser", "intensity", "filter", "shutterconfig"])
+    elif name == "camera settings":
+        print_change_table(result, list(result.get("target", {}).keys()))
+    elif name == "waveform parameters":
+        print_change_table(result, list(result.get("after", {}).keys()))
+    elif name == "stage motion":
+        for item in result.get("per_axis", []):
+            move = item.get("move")
+            delta = item.get("delta")
+            before = item.get("before", {})
+            after = item.get("after", {})
+            axis = "theta_pos" if move == "theta_rel" else move.replace("_rel", "_pos")
+            print(
+                f"  {move:<12} {delta:+g}: "
+                f"{short_value(before.get(axis))} -> {short_value(after.get(axis))}"
+            )
+        print_position("Final position", result.get("final", {}))
+    elif name == "absolute motion":
+        print_position("Initial position", result.get("initial", {}))
+        print_kv("Absolute target", result.get("target", {}))
+        print_position("After move", result.get("after", {}))
+        print_position("Final position", result.get("final", {}))
+    elif name == "zero/unzero":
+        print_position("Before", result.get("before", {}))
+        print_position("Zeroed", result.get("zeroed", {}))
+        print_position("Restored", result.get("restored", {}))
+    elif name == "sample helper moves":
+        print_position("Initial position", result.get("initial", {}))
+        print_position("Load sample", result.get("loaded", {}))
+        print_position("Unload sample", result.get("unloaded", {}))
+        print_position("Center sample", result.get("centered", {}))
+        print_position("Final position", result.get("final", {}))
+    elif name == "shutter open/close":
+        print_named_change_table(
+            result,
+            [
+                ("before", "before"),
+                ("opened", "opened"),
+                ("closed", "closed"),
+                ("restored", "restored"),
+            ],
+            ["shutterconfig", "shutterstate"],
+        )
+    elif name == "ETL reload/update":
+        print_kv("Laser used", result.get("laser"))
+        print_kv("Zoom used", result.get("zoom"))
+        print_named_change_table(
+            result,
+            [
+                ("before", "before"),
+                ("cfg reload", "after_cfg_reload"),
+                ("laser update", "after_laser_update"),
+                ("zoom update", "after_zoom_update"),
+                ("restored", "restored"),
+            ],
+            [
+                "ETL_cfg_file",
+                "etl_l_amplitude",
+                "etl_l_offset",
+                "etl_r_amplitude",
+                "etl_r_offset",
+            ],
+        )
+    elif name == "zoom":
+        print_change_table(result, ["zoom"])
+    elif name == "snap(write_flag=False)":
+        print_kv("State", f"{result.get('before_state')} -> {result.get('after_state')}")
+        print_position("Before position", result.get("before_position", {}))
+        print_position("After position", result.get("after_position", {}))
+
+
+def numeric_target(key: str, value):
+    if isinstance(value, bool):
+        return not value
+    if isinstance(value, int) and not isinstance(value, bool):
+        if key == "samplerate":
+            return max(1, value + 1)
+        return value + 1
+    if isinstance(value, float):
+        if key == "sweeptime":
+            return max(0.001, value + 0.001)
+        if "phase" in key:
+            return value + 0.01
+        if "%" in key or "duty_cycle" in key or "pulse" in key:
+            return value - 0.1 if value >= 99.0 else value + 0.1
+        return value + 0.01
+    return value
+
+
+def test_probe(client: RemoteScriptingClient, raw_dir: Path | None) -> dict:
+    body = """
+keys = (
+    'state', 'position', 'position_absolute', 'laser', 'intensity',
+    'filter', 'shutterconfig', 'zoom', 'ETL_cfg_file',
+    'camera_exposure_time', 'camera_line_interval',
+    'camera_display_live_subsampling', 'camera_display_acquisition_subsampling',
+    'camera_binning',
+)
+snapshot = {}
+for key in keys:
+    try:
+        snapshot[key] = core.state[key]
+    except Exception as exc:
+        snapshot[key] = '<missing: %s>' % exc
+
+__result['state'] = snapshot
+__result['stage_class'] = core.serial_worker.stage.__class__.__name__
+__result['config'] = {
+    'lasers': list(core.cfg.laserdict.keys()),
+    'filters': list(core.cfg.filterdict.keys()),
+    'shutters': list(core.cfg.shutteroptions),
+    'zooms': list(core.cfg.zoomdict.keys()),
+}
+core.sig_status_message.emit('Remote scripting full test: probe reached Core')
+"""
+    return run_remote_json(client, "probe", body, raw_dir)
+
+
+def test_controls(client: RemoteScriptingClient, restore: bool, raw_dir: Path | None) -> dict:
+    body = f"""
+control_keys = ('laser', 'intensity', 'filter', 'shutterconfig')
+before = {{}}
+for key in control_keys:
+    before[key] = core.state[key]
+
+lasers = list(core.cfg.laserdict.keys())
+filters = list(core.cfg.filterdict.keys())
+shutters = list(core.cfg.shutteroptions)
+
+target_laser = lasers[(lasers.index(before['laser']) + 1) % len(lasers)] if before['laser'] in lasers and len(lasers) > 1 else before['laser']
+target_filter = filters[(filters.index(before['filter']) + 1) % len(filters)] if before['filter'] in filters and len(filters) > 1 else before['filter']
+target_shutter = shutters[(shutters.index(before['shutterconfig']) + 1) % len(shutters)] if before['shutterconfig'] in shutters and len(shutters) > 1 else before['shutterconfig']
+target_intensity = 25 if before['intensity'] != 25 else 50
+
+core.set_laser(target_laser, update_etl=False)
+core.set_intensity(target_intensity)
+core.serial_worker.set_filter(target_filter)
+core.set_shutterconfig(target_shutter)
+__pump(150)
+
+after = {{
+    'laser': core.state['laser'],
+    'intensity': core.state['intensity'],
+    'filter': core.state['filter'],
+    'shutterconfig': core.state['shutterconfig'],
+}}
+
+if {restore!r}:
+    core.set_laser(before['laser'], update_etl=False)
+    core.set_intensity(before['intensity'])
+    core.serial_worker.set_filter(before['filter'])
+    core.set_shutterconfig(before['shutterconfig'])
+    __pump(150)
+
+restored = {{
+    'laser': core.state['laser'],
+    'intensity': core.state['intensity'],
+    'filter': core.state['filter'],
+    'shutterconfig': core.state['shutterconfig'],
+}}
+
+__result['before'] = before
+__result['target'] = {{
+    'laser': target_laser,
+    'intensity': target_intensity,
+    'filter': target_filter,
+    'shutterconfig': target_shutter,
+}}
+__result['after'] = after
+__result['restored'] = restored
+"""
+    return run_remote_json(client, "controls", body, raw_dir)
+
+
+def test_camera_settings(
+    client: RemoteScriptingClient,
+    include_binning: bool,
+    restore: bool,
+    raw_dir: Path | None,
+) -> dict:
+    binning_part = ""
+    if include_binning:
+        binning_part = """
+before['camera_binning'] = core.state['camera_binning']
+target_binning = '2x2' if before['camera_binning'] != '2x2' else '1x1'
+core.state_request_handler({'camera_binning': target_binning})
+target['camera_binning'] = target_binning
+"""
+    restore_binning_part = ""
+    if include_binning:
+        restore_binning_part = """
+    core.state_request_handler({'camera_binning': before['camera_binning']})
+"""
+
+    body = f"""
+before = {{
+    'camera_exposure_time': core.state['camera_exposure_time'],
+    'camera_line_interval': core.state['camera_line_interval'],
+    'camera_display_live_subsampling': core.state['camera_display_live_subsampling'],
+    'camera_display_acquisition_subsampling': core.state['camera_display_acquisition_subsampling'],
+}}
+target = {{
+    'camera_exposure_time': before['camera_exposure_time'] + 0.001,
+    'camera_line_interval': before['camera_line_interval'] + 0.000001,
+    'camera_display_live_subsampling': 1 if before['camera_display_live_subsampling'] != 1 else 2,
+    'camera_display_acquisition_subsampling': 1 if before['camera_display_acquisition_subsampling'] != 1 else 2,
+}}
+
+core.set_camera_exposure_time(target['camera_exposure_time'])
+core.set_camera_line_interval(target['camera_line_interval'])
+core.state_request_handler({{'camera_display_live_subsampling': target['camera_display_live_subsampling']}})
+core.state_request_handler({{'camera_display_acquisition_subsampling': target['camera_display_acquisition_subsampling']}})
+{binning_part}
+__pump(150)
+
+after = {{}}
+for key in target:
+    after[key] = core.state[key]
+
+if {restore!r}:
+    core.set_camera_exposure_time(before['camera_exposure_time'])
+    core.set_camera_line_interval(before['camera_line_interval'])
+    core.state_request_handler({{'camera_display_live_subsampling': before['camera_display_live_subsampling']}})
+    core.state_request_handler({{'camera_display_acquisition_subsampling': before['camera_display_acquisition_subsampling']}})
+{restore_binning_part}
+    __pump(150)
+
+restored = {{}}
+for key in before:
+    restored[key] = core.state[key]
+
+__result['before'] = before
+__result['target'] = target
+__result['after'] = after
+__result['restored'] = restored
+"""
+    return run_remote_json(client, "camera_settings", body, raw_dir)
+
+
+def test_waveform_parameters(client: RemoteScriptingClient, restore: bool, raw_dir: Path | None) -> dict:
+    keys = [
+        "samplerate",
+        "sweeptime",
+        "etl_l_delay_%",
+        "etl_l_ramp_rising_%",
+        "etl_l_ramp_falling_%",
+        "etl_l_amplitude",
+        "etl_l_offset",
+        "etl_r_delay_%",
+        "etl_r_ramp_rising_%",
+        "etl_r_ramp_falling_%",
+        "etl_r_amplitude",
+        "etl_r_offset",
+        "galvo_l_frequency",
+        "galvo_l_amplitude",
+        "galvo_l_offset",
+        "galvo_l_duty_cycle",
+        "galvo_l_phase",
+        "galvo_r_frequency",
+        "galvo_r_offset",
+        "galvo_r_duty_cycle",
+        "galvo_r_phase",
+        "laser_l_delay_%",
+        "laser_l_pulse_%",
+        "laser_r_delay_%",
+        "laser_r_pulse_%",
+        "camera_delay_%",
+        "camera_pulse_%",
+    ]
+    body = f"""
+keys = {keys!r}
+before = {{}}
+target = {{}}
+after = {{}}
+
+def make_target(key, value):
+    if isinstance(value, bool):
+        return not value
+    if isinstance(value, int) and not isinstance(value, bool):
+        if key == 'samplerate':
+            return max(1, value + 1)
+        return value + 1
+    if isinstance(value, float):
+        if key == 'sweeptime':
+            return max(0.001, value + 0.001)
+        if 'phase' in key:
+            return value + 0.01
+        if '%' in key or 'duty_cycle' in key or 'pulse' in key:
+            return value - 0.1 if value >= 99.0 else value + 0.1
+        return value + 0.01
+    return value
+
+for key in keys:
+    try:
+        value = core.state[key]
+    except Exception:
+        continue
+    before[key] = value
+    target[key] = make_target(key, value)
+    core.state_request_handler({{key: target[key]}})
+    __pump(20)
+    try:
+        after[key] = core.state[key]
+    except Exception as exc:
+        after[key] = '<readback failed: %s>' % exc
+
+if {restore!r}:
+    for key, value in before.items():
+        core.state_request_handler({{key: value}})
+        __pump(20)
+
+restored = {{}}
+for key in before:
+    try:
+        restored[key] = core.state[key]
+    except Exception as exc:
+        restored[key] = '<readback failed: %s>' % exc
+
+__result['before'] = before
+__result['target'] = target
+__result['after'] = after
+__result['restored'] = restored
+"""
+    return run_remote_json(client, "waveform_parameters", body, raw_dir)
+
+
+def test_stage_motion(
+    client: RemoteScriptingClient,
+    step_um: float,
+    theta_step: float,
+    restore: bool,
+    raw_dir: Path | None,
+) -> dict:
+    body = f"""
+moves = [
+    ('x_rel', {step_um!r}),
+    ('y_rel', {step_um!r}),
+    ('z_rel', {step_um!r}),
+    ('f_rel', {step_um!r}),
+    ('theta_rel', {theta_step!r}),
+]
+
+initial = dict(core.state['position'])
+per_axis = []
+
+for key, delta in moves:
+    before = dict(core.state['position'])
+    core.serial_worker.move_relative({{key: delta}}, wait_until_done=True)
+    core.serial_worker.stage.report_position()
+    __pump(50)
+    after = dict(core.state['position'])
+    per_axis.append({{'move': key, 'delta': delta, 'before': before, 'after': after}})
+
+if {restore!r}:
+    for key, delta in reversed(moves):
+        core.serial_worker.move_relative({{key: -delta}}, wait_until_done=True)
+        core.serial_worker.stage.report_position()
+        __pump(50)
+
+final = dict(core.state['position'])
+core.sig_status_message.emit('Remote scripting full test: stage motion complete')
+__result['initial'] = initial
+__result['per_axis'] = per_axis
+__result['final'] = final
+"""
+    return run_remote_json(client, "stage_motion", body, raw_dir)
+
+
+def test_absolute_motion(
+    client: RemoteScriptingClient,
+    step_um: float,
+    theta_step: float,
+    restore: bool,
+    raw_dir: Path | None,
+) -> dict:
+    body = f"""
+initial = dict(core.state['position'])
+target = {{
+    'x_abs': initial['x_pos'] + {step_um!r},
+    'y_abs': initial['y_pos'] + {step_um!r},
+    'z_abs': initial['z_pos'] + {step_um!r},
+    'f_abs': initial['f_pos'] + {step_um!r},
+    'theta_abs': initial['theta_pos'] + {theta_step!r},
+}}
+
+core.serial_worker.move_absolute(target, wait_until_done=True, use_internal_position=True)
+core.serial_worker.stage.report_position()
+__pump(100)
+after = dict(core.state['position'])
+
+if {restore!r}:
+    restore_target = {{
+        'x_abs': initial['x_pos'],
+        'y_abs': initial['y_pos'],
+        'z_abs': initial['z_pos'],
+        'f_abs': initial['f_pos'],
+        'theta_abs': initial['theta_pos'],
+    }}
+    core.serial_worker.move_absolute(restore_target, wait_until_done=True, use_internal_position=True)
+    core.serial_worker.stage.report_position()
+    __pump(100)
+
+final = dict(core.state['position'])
+core.sig_status_message.emit('Remote scripting full test: absolute stage motion complete')
+__result['initial'] = initial
+__result['target'] = target
+__result['after'] = after
+__result['final'] = final
+"""
+    return run_remote_json(client, "absolute_motion", body, raw_dir)
+
+
+def test_zero_unzero(client: RemoteScriptingClient, raw_dir: Path | None) -> dict:
+    body = """
+stage = core.serial_worker.stage
+before = dict(core.state['position'])
+raw_x_before = stage.x_pos
+offset_x_before = stage.int_x_pos_offset
+
+stage.zero_axes(['x'])
+stage.report_position()
+__pump(50)
+zeroed = dict(core.state['position'])
+
+stage.unzero_axes(['x'])
+stage.x_pos = raw_x_before
+stage.int_x_pos_offset = offset_x_before
+stage.report_position()
+__pump(50)
+restored = dict(core.state['position'])
+
+if abs(zeroed['x_pos']) > 1e-9:
+    raise AssertionError('zero_axes did not make X readout zero: %r' % zeroed)
+if abs(restored['x_pos'] - before['x_pos']) > 1e-9:
+    raise AssertionError('unzero/cleanup did not restore X readout: before=%r restored=%r' % (before, restored))
+
+__result['before'] = before
+__result['zeroed'] = zeroed
+__result['restored'] = restored
+"""
+    return run_remote_json(client, "zero_unzero", body, raw_dir)
+
+
+def test_sample_moves(client: RemoteScriptingClient, restore: bool, raw_dir: Path | None) -> dict:
+    body = f"""
+initial = dict(core.state['position'])
+stage = core.serial_worker.stage
+
+stage.load_sample()
+stage.report_position()
+__pump(100)
+loaded = dict(core.state['position'])
+
+stage.unload_sample()
+stage.report_position()
+__pump(100)
+unloaded = dict(core.state['position'])
+
+stage.center_sample()
+stage.report_position()
+__pump(100)
+centered = dict(core.state['position'])
+
+if {restore!r}:
+    restore_target = {{
+        'x_abs': initial['x_pos'],
+        'y_abs': initial['y_pos'],
+        'z_abs': initial['z_pos'],
+        'f_abs': initial['f_pos'],
+        'theta_abs': initial['theta_pos'],
+    }}
+    core.serial_worker.move_absolute(restore_target, wait_until_done=True, use_internal_position=True)
+    core.serial_worker.stage.report_position()
+    __pump(100)
+
+final = dict(core.state['position'])
+core.sig_status_message.emit('Remote scripting full test: sample helper moves complete')
+__result['initial'] = initial
+__result['loaded'] = loaded
+__result['unloaded'] = unloaded
+__result['centered'] = centered
+__result['final'] = final
+"""
+    return run_remote_json(client, "sample_moves", body, raw_dir)
+
+
+def test_shutters(client: RemoteScriptingClient, restore: bool, raw_dir: Path | None) -> dict:
+    body = f"""
+before = {{
+    'shutterstate': core.state['shutterstate'],
+    'shutterconfig': core.state['shutterconfig'],
+}}
+
+core.open_shutters()
+__pump(50)
+opened = {{
+    'shutterstate': core.state['shutterstate'],
+    'shutterconfig': core.state['shutterconfig'],
+}}
+
+core.close_shutters()
+__pump(50)
+closed = {{
+    'shutterstate': core.state['shutterstate'],
+    'shutterconfig': core.state['shutterconfig'],
+}}
+
+if {restore!r} and before['shutterstate']:
+    core.open_shutters()
+elif {restore!r}:
+    core.close_shutters()
+__pump(50)
+
+restored = {{
+    'shutterstate': core.state['shutterstate'],
+    'shutterconfig': core.state['shutterconfig'],
+}}
+core.sig_status_message.emit('Remote scripting full test: shutter open/close complete')
+__result['before'] = before
+__result['opened'] = opened
+__result['closed'] = closed
+__result['restored'] = restored
+"""
+    return run_remote_json(client, "shutters", body, raw_dir)
+
+
+def test_etl_updates(client: RemoteScriptingClient, restore: bool, raw_dir: Path | None) -> dict:
+    keys = [
+        "ETL_cfg_file",
+        "etl_l_amplitude",
+        "etl_l_offset",
+        "etl_r_amplitude",
+        "etl_r_offset",
+    ]
+    body = f"""
+keys = {keys!r}
+before = {{key: core.state[key] for key in keys}}
+laser = core.state['laser']
+zoom = core.state['zoom']
+
+core.state_request_handler({{'ETL_cfg_file': before['ETL_cfg_file']}})
+__pump(100)
+after_cfg_reload = {{key: core.state[key] for key in keys}}
+
+core.state_request_handler({{'set_etls_according_to_laser': laser}})
+__pump(100)
+after_laser_update = {{key: core.state[key] for key in keys}}
+
+core.state_request_handler({{'set_etls_according_to_zoom': zoom}})
+__pump(100)
+after_zoom_update = {{key: core.state[key] for key in keys}}
+
+if {restore!r}:
+    for key, value in before.items():
+        core.state_request_handler({{key: value}})
+        __pump(20)
+
+restored = {{key: core.state[key] for key in keys}}
+core.sig_status_message.emit('Remote scripting full test: ETL reload/update complete')
+__result['before'] = before
+__result['after_cfg_reload'] = after_cfg_reload
+__result['after_laser_update'] = after_laser_update
+__result['after_zoom_update'] = after_zoom_update
+__result['restored'] = restored
+__result['laser'] = laser
+__result['zoom'] = zoom
+"""
+    return run_remote_json(client, "etl_updates", body, raw_dir)
+
+
+def test_zoom(client: RemoteScriptingClient, restore: bool, raw_dir: Path | None) -> dict:
+    body = f"""
+zooms = list(core.cfg.zoomdict.keys())
+before = core.state['zoom']
+if before in zooms and len(zooms) > 1:
+    target = zooms[(zooms.index(before) + 1) % len(zooms)]
+else:
+    target = before
+core.set_zoom(target, wait_until_done=True, update_etl=False)
+__pump(100)
+after = core.state['zoom']
+if {restore!r} and before != after:
+    core.set_zoom(before, wait_until_done=True, update_etl=False)
+    __pump(100)
+restored = core.state['zoom']
+__result['before'] = {{'zoom': before}}
+__result['target'] = {{'zoom': target}}
+__result['after'] = {{'zoom': after}}
+__result['restored'] = {{'zoom': restored}}
+"""
+    return run_remote_json(client, "zoom", body, raw_dir)
+
+
+def test_snap(client: RemoteScriptingClient, raw_dir: Path | None) -> dict:
+    body = """
+before_state = core.state['state']
+before_position = dict(core.state['position'])
+core.snap(write_flag=False, laser_blanking=True)
+__pump(100)
+after_state = core.state['state']
+after_position = dict(core.state['position'])
+core.sig_status_message.emit('Remote scripting full test: snap(write_flag=False) complete')
+__result['before_state'] = before_state
+__result['after_state'] = after_state
+__result['before_position'] = before_position
+__result['after_position'] = after_position
+"""
+    return run_remote_json(client, "snap_no_write", body, raw_dir)
+
+
+def validate_changed(result: dict, keys: list[str]) -> str:
+    changed = []
+    unchanged = []
+    for key in keys:
+        before = result.get("before", {}).get(key)
+        after = result.get("after", {}).get(key)
+        if before != after:
+            changed.append(key)
+        else:
+            unchanged.append(key)
+    parts = []
+    if changed:
+        parts.append("changed: " + ", ".join(changed))
+    if unchanged:
+        parts.append("unchanged: " + ", ".join(unchanged))
+    return "; ".join(parts)
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        description="Run a comprehensive smoke test against mesoSPIM remote scripting."
+    )
+    parser.add_argument(
+        "--profile",
+        choices=("safe", "full-demo"),
+        default="full-demo",
+        help=(
+            "Test profile. 'full-demo' is the default and exercises all demo-mode "
+            "remote scripting paths. 'safe' avoids motion/zoom/snap."
+        ),
+    )
+    parser.add_argument("--host", default="127.0.0.1")
+    parser.add_argument("--port", type=int, default=42000)
+    parser.add_argument(
+        "--token",
+        default=os.environ.get("MESOSPIM_REMOTE_TOKEN"),
+        help="Remote scripting token. Defaults to MESOSPIM_REMOTE_TOKEN. Omit only when the server has no token.",
+    )
+    parser.add_argument(
+        "--no-token",
+        action="store_true",
+        help="Connect without authentication. Use only if the remote scripting dialog token is blank.",
+    )
+    parser.add_argument(
+        "--timeout",
+        type=float,
+        default=30.0,
+        help="Socket timeout in seconds. Full demo zoom tests can take several seconds.",
+    )
+    parser.add_argument("--raw-dir", type=Path, default=None, help="Optional directory for raw remote replies.")
+    parser.add_argument(
+        "--allow-non-demo",
+        action="store_true",
+        help="Allow running even if the remote stage is not mesoSPIM_DemoStage.",
+    )
+    parser.add_argument(
+        "--show-remote-output",
+        action="store_true",
+        help="Print stdout/stderr emitted by each script inside mesoSPIM.",
+    )
+    parser.add_argument("--no-restore", action="store_true", help="Leave changed settings/position at test targets.")
+    parser.add_argument(
+        "--allow-motion",
+        action="store_true",
+        help="Test X/Y/Z/F/theta relative moves and restore them unless --no-restore is set.",
+    )
+    parser.add_argument("--step-um", type=float, default=100.0, help="Relative X/Y/Z/F move in micrometres.")
+    parser.add_argument("--theta-step", type=float, default=1.0, help="Relative theta move in degrees.")
+    parser.add_argument(
+        "--include-zeroing",
+        action="store_true",
+        help="Test zero/unzero on X. Requires --allow-motion because it changes position readout.",
+    )
+    parser.add_argument(
+        "--include-sample-moves",
+        action="store_true",
+        help="Test load_sample/unload_sample/center_sample. Demo-safe, but can move real hardware far.",
+    )
+    parser.add_argument(
+        "--include-shutters",
+        action="store_true",
+        help="Test open_shutters/close_shutters. Demo-safe, but opens/closes real shutters on hardware.",
+    )
+    parser.add_argument(
+        "--include-etl-updates",
+        action="store_true",
+        help="Test ETL config reload and set_etls_according_to_laser/zoom update paths.",
+    )
+    parser.add_argument(
+        "--include-zoom",
+        action="store_true",
+        help="Test changing zoom and restore it. Can move focus/objective hardware.",
+    )
+    parser.add_argument(
+        "--include-snap",
+        action="store_true",
+        help="Test core.snap(write_flag=False). Can trigger camera/illumination hardware.",
+    )
+    parser.add_argument(
+        "--include-camera-binning",
+        action="store_true",
+        help="Test camera_binning. Avoid on real hardware unless you want to exercise binning changes.",
+    )
+    return parser
+
+
+def apply_profile(args: argparse.Namespace) -> None:
+    if args.profile == "full-demo":
+        args.allow_motion = True
+        args.include_zeroing = True
+        args.include_sample_moves = True
+        args.include_shutters = True
+        args.include_etl_updates = True
+        args.include_zoom = True
+        args.include_snap = True
+        args.include_camera_binning = True
+
+
+def resolve_token(args: argparse.Namespace) -> str | None:
+    if args.no_token:
+        return None
+    if args.token:
+        return args.token
+    if sys.stdin.isatty():
+        token = getpass.getpass("Remote scripting token (leave blank if disabled): ")
+        return token or None
+    return None
+
+
+def scrubbed_argv(argv: list[str]) -> str:
+    scrubbed = []
+    skip_next = False
+    for item in argv:
+        if skip_next:
+            scrubbed.append("<token>")
+            skip_next = False
+            continue
+        if item == "--token":
+            scrubbed.append(item)
+            skip_next = True
+        elif item.startswith("--token="):
+            scrubbed.append("--token=<token>")
+        else:
+            scrubbed.append(item)
+    return " ".join(scrubbed)
+
+
+def print_header(args: argparse.Namespace, restore: bool) -> None:
+    print("=" * 78)
+    print("mesoSPIM Remote Scripting Full Test")
+    print("=" * 78)
+    print(f"  {'Command':<24} {scrubbed_argv(sys.argv)}")
+    print_kv("Client Python", sys.executable)
+    print_kv("Target", f"{args.host}:{args.port}")
+    print_kv("Profile", args.profile)
+    print_kv("Default behavior", "full demo test suite")
+    print_kv("Expected mode", "demo stage")
+    print_kv("Token", "provided" if args.token else "off")
+    print_kv("Restore changes", restore)
+    if args.raw_dir is not None:
+        print_kv("Raw replies", args.raw_dir)
+    print()
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = build_parser().parse_args(argv)
+    apply_profile(args)
+    args.token = resolve_token(args)
+    restore = not args.no_restore
+    failures = 0
+    skipped = 0
+
+    global SHOW_REMOTE_OUTPUT
+    SHOW_REMOTE_OUTPUT = args.show_remote_output
+
+    print_header(args, restore)
+
+    tests = []
+
+    def add(name, func):
+        tests.append((name, func))
+
+    add("probe", lambda client: test_probe(client, args.raw_dir))
+    add("status/control widgets", lambda client: test_controls(client, restore, args.raw_dir))
+    add(
+        "camera settings",
+        lambda client: test_camera_settings(client, args.include_camera_binning, restore, args.raw_dir),
+    )
+    add("waveform parameters", lambda client: test_waveform_parameters(client, restore, args.raw_dir))
+
+    if args.include_etl_updates:
+        add("ETL reload/update", lambda client: test_etl_updates(client, restore, args.raw_dir))
+
+    if args.allow_motion:
+        add(
+            "stage motion",
+            lambda client: test_stage_motion(client, args.step_um, args.theta_step, restore, args.raw_dir),
+        )
+        add(
+            "absolute motion",
+            lambda client: test_absolute_motion(client, args.step_um, args.theta_step, restore, args.raw_dir),
+        )
+        if args.include_zeroing:
+            add("zero/unzero", lambda client: test_zero_unzero(client, args.raw_dir))
+        if args.include_sample_moves:
+            add("sample helper moves", lambda client: test_sample_moves(client, restore, args.raw_dir))
+    else:
+        skipped += 1
+        print_result("SKIP", "stage motion", "pass --allow-motion to test X/Y/Z/F/theta moves")
+
+    if args.include_zeroing and not args.allow_motion:
+        skipped += 1
+        print_result("SKIP", "zero/unzero", "--include-zeroing requires --allow-motion")
+    if args.include_sample_moves and not args.allow_motion:
+        skipped += 1
+        print_result("SKIP", "sample helper moves", "--include-sample-moves requires --allow-motion")
+
+    if args.include_shutters:
+        add("shutter open/close", lambda client: test_shutters(client, restore, args.raw_dir))
+
+    if args.include_zoom:
+        add("zoom", lambda client: test_zoom(client, restore, args.raw_dir))
+    else:
+        skipped += 1
+        print_result("SKIP", "zoom", "pass --include-zoom to test objective/zoom changes")
+
+    if args.include_snap:
+        add("snap(write_flag=False)", lambda client: test_snap(client, args.raw_dir))
+    else:
+        skipped += 1
+        print_result("SKIP", "snap(write_flag=False)", "pass --include-snap to trigger a no-write snap")
+
+    try:
+        with RemoteScriptingClient(args.host, args.port, args.token, args.timeout) as client:
+            for name, func in tests:
+                started = time.perf_counter()
+                print()
+                print("-" * 78)
+                print(f"Running: {name}")
+                try:
+                    result = func(client)
+                    elapsed = time.perf_counter() - started
+                    if name == "probe" and not args.allow_non_demo:
+                        stage_class = result.get("stage_class")
+                        if stage_class != "mesoSPIM_DemoStage":
+                            raise RemoteScriptingError(
+                                f"remote stage is {stage_class!r}, expected 'mesoSPIM_DemoStage'; "
+                                "this script is demo-only unless --allow-non-demo is set"
+                            )
+                    print_result("PASS", name, f"{elapsed:.2f}s")
+                    print_test_details(name, result)
+                except Exception as exc:
+                    failures += 1
+                    print_result("FAIL", name, str(exc))
+    except Exception as exc:
+        print_result("FAIL", "connect/auth", str(exc))
+        return 2
+
+    print()
+    print("=" * 78)
+    print("Summary")
+    print("=" * 78)
+    print_kv("Tests run", len(tests))
+    print_kv("Skipped", skipped)
+    print_kv("Failures", failures)
+    if failures:
+        print(f"completed with {failures} failure(s)")
+        return 1
+    print("completed successfully")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/mesoSPIM/src/mesoSPIM_Core.py
+++ b/mesoSPIM/src/mesoSPIM_Core.py
@@ -1178,6 +1178,43 @@ class mesoSPIM_Core(QtCore.QObject):
         self.state['state']='idle'
         self.sig_update_gui_from_state.emit()
 
+    # Reports the outcome of a start_remote_scripting attempt back to the GUI
+    # (ok, message) so the dialog never shows a false "running" on a bind failure.
+    sig_remote_scripting_started = QtCore.pyqtSignal(bool, str)
+
+    @QtCore.pyqtSlot(str, int, str)
+    def start_remote_scripting(self, host, port, token):
+        '''Start the remote scripting server (Tools -> Remote Scripting...).
+
+        Runs on the Core's own thread (invoked via a queued connection) so the
+        server's QTcpServer lives here, where execute_script runs. `token` gates
+        access: when non-empty a client must send it before any script runs.
+        Restart-safe: stops any prior instance first. Emits
+        sig_remote_scripting_started(ok, message); on a bind failure (e.g. port in
+        use) ok is False so the GUI can report it. See mesoSPIM_RemoteScripting.py.
+        '''
+        from .mesoSPIM_RemoteScripting import RemoteScriptingServer
+        self.stop_remote_scripting()
+        try:
+            self._remote_scripting_server = RemoteScriptingServer(self, host, int(port), token or None)
+        except Exception as exc:
+            logger.exception('Remote scripting server failed to start')
+            self.sig_remote_scripting_started.emit(False, str(exc))
+            return
+        logger.info(f'Remote scripting server on {host}:{port} (token {"set" if token else "off"})')
+        self.sig_remote_scripting_started.emit(True, f'{host}:{port}')
+
+    @QtCore.pyqtSlot()
+    def stop_remote_scripting(self):
+        '''Stop the remote scripting server if running (idempotent).'''
+        srv = getattr(self, '_remote_scripting_server', None)
+        if srv is not None:
+            try:
+                srv.stop()
+            except Exception:
+                logger.exception('Error stopping remote scripting server')
+            self._remote_scripting_server = None
+
     def lightsheet_alignment_mode(self):
         """Continuous live mode that alternates left/right shutters for dual-lightsheet co-alignment.
 

--- a/mesoSPIM/src/mesoSPIM_MainWindow.py
+++ b/mesoSPIM/src/mesoSPIM_MainWindow.py
@@ -77,6 +77,10 @@ class mesoSPIM_MainWindow(QtWidgets.QMainWindow):
 
     sig_save_etl_config = QtCore.pyqtSignal()
     sig_poke_demo_thread = QtCore.pyqtSignal()
+    # Remote scripting server (Tools -> Remote Scripting...). Emitted to the Core
+    # (queued) so the server's socket lives on the Core's own thread.
+    sig_start_remote_scripting = QtCore.pyqtSignal(str, int, str)
+    sig_stop_remote_scripting = QtCore.pyqtSignal()
     sig_launch_optimizer = QtCore.pyqtSignal(dict)
     sig_launch_contrast_window = QtCore.pyqtSignal()
     sig_launch_processor_chain_window = QtCore.pyqtSignal()
@@ -196,6 +200,9 @@ class mesoSPIM_MainWindow(QtWidgets.QMainWindow):
         self.sig_launch_optimizer.connect(self.launch_optimizer)
         self.sig_launch_contrast_window.connect(self.launch_contrast_window)
         self.sig_launch_processor_chain_window.connect(self.launch_processor_chain_window)
+        self.sig_start_remote_scripting.connect(self.core.start_remote_scripting, type=QtCore.Qt.QueuedConnection)
+        self.sig_stop_remote_scripting.connect(self.core.stop_remote_scripting, type=QtCore.Qt.QueuedConnection)
+        self.core.sig_remote_scripting_started.connect(self.on_remote_scripting_started)
 
         ''' Start the thread '''
         self.core_thread.start(QtCore.QThread.HighestPriority)
@@ -273,6 +280,9 @@ class mesoSPIM_MainWindow(QtWidgets.QMainWindow):
     def close_app(self):
         #self.log_display_handler.flushOnClose = False #discontinued
         logger.info('Closing the application')
+        if getattr(self, '_remote_scripting_running', False):
+            self.sig_stop_remote_scripting.emit()
+            self._remote_scripting_running = False
         self.camera_window.close()
         self.acquisition_manager_window.close()
         if self.optimizer:
@@ -419,6 +429,23 @@ class mesoSPIM_MainWindow(QtWidgets.QMainWindow):
         self.actionOpen_Acquisition_Manager.triggered.connect(self.acquisition_manager_window.show)
         self.actionOpen_Tile_Overview.triggered.connect(self.tile_view_window.show)
         self.actionCascade_windows.triggered.connect(self.cascade_all_windows)
+        # Add a "Tools -> Remote Scripting..." entry programmatically (no .ui change).
+        # `self.menuBar` is the QMenuBar *widget* from the .ui (it shadows
+        # QMainWindow.menuBar()), so add to it as an attribute. Reuse an existing
+        # Tools menu if one is ever added, rather than creating a duplicate.
+        self._remote_scripting_running = False
+        self._rs_refresh = None
+        self.menuTools = None
+        for _action in self.menuBar.actions():
+            if _action.menu() is not None and _action.text().replace('&', '') == 'Tools':
+                self.menuTools = _action.menu()
+                break
+        if self.menuTools is None:
+            self.menuTools = self.menuBar.addMenu('Tools')
+        self.actionRemoteScripting = QtWidgets.QAction('Remote Scripting...', self)
+        self.actionRemoteScripting.setStatusTip('Start/stop the external Python scripting server')
+        self.actionRemoteScripting.triggered.connect(self.open_remote_scripting_dialog)
+        self.menuTools.addAction(self.actionRemoteScripting)
 
         # Add Processor Chain menu item to View menu
         self.actionProcessor_Chain = QtWidgets.QAction("Processor Chain", self)
@@ -1137,6 +1164,104 @@ class mesoSPIM_MainWindow(QtWidgets.QMainWindow):
 
     def display_warning(self, string):
         warning = QtWidgets.QMessageBox.warning(None,'mesoSPIM Warning', string, QtWidgets.QMessageBox.Ok)
+
+    def on_remote_scripting_started(self, ok, message):
+        '''Result of a start attempt from the Core (queued): update state + dialog.
+
+        On failure (e.g. the port is in use) the server did NOT start, so the
+        dialog must not show "running". Warn the operator with the reason.
+        '''
+        self._remote_scripting_running = ok
+        if not ok:
+            QtWidgets.QMessageBox.warning(
+                self, 'Remote Scripting', f'Could not start the server: {message}')
+        if self._rs_refresh is not None:
+            self._rs_refresh()
+
+    def open_remote_scripting_dialog(self):
+        '''Start/stop the remote scripting server (external Python control API).
+
+        Off by default. A client sends a Python script; it runs in the Core
+        context (the same Script Window path) and its console output is returned.
+        A script is ARBITRARY code on this PC, so: host 127.0.0.1 = same machine
+        only; set a token before exposing it on the network; plain TCP, so the
+        token gates casual LAN access but is not sniffer-proof (tunnel for
+        untrusted nets).
+        '''
+        import secrets
+        dlg = QtWidgets.QDialog(self)
+        dlg.setWindowTitle('Remote Scripting')
+        form = QtWidgets.QFormLayout(dlg)
+        warn = QtWidgets.QLabel('Runs arbitrary Python on this PC. Use a token to expose on a network.')
+        warn.setWordWrap(True)
+        form.addRow(warn)
+        host_edit = QtWidgets.QLineEdit(getattr(self, '_rs_host', '127.0.0.1'))
+        port_edit = QtWidgets.QLineEdit(str(getattr(self, '_rs_port', 42000)))
+        # Secure by default: pre-fill a fresh random token so starting the server
+        # is never accidentally open. The operator can clear it to run open on
+        # localhost (a network bind with no token is still confirmed in do_start).
+        token_edit = QtWidgets.QLineEdit(getattr(self, '_rs_token', '') or secrets.token_urlsafe(16))
+        token_edit.setPlaceholderText('blank = open (localhost only)')
+        gen_btn = QtWidgets.QPushButton('Generate')
+        gen_btn.clicked.connect(lambda: token_edit.setText(secrets.token_urlsafe(16)))
+        token_row = QtWidgets.QHBoxLayout()
+        token_row.addWidget(token_edit)
+        token_row.addWidget(gen_btn)
+        status = QtWidgets.QLabel()
+        form.addRow('Host:', host_edit)
+        form.addRow('Port:', port_edit)
+        form.addRow('Token:', token_row)
+        form.addRow('Status:', status)
+        start_btn = QtWidgets.QPushButton('Start')
+        stop_btn = QtWidgets.QPushButton('Stop')
+        btns = QtWidgets.QHBoxLayout()
+        btns.addWidget(start_btn)
+        btns.addWidget(stop_btn)
+        form.addRow(btns)
+
+        def refresh():
+            running = self._remote_scripting_running
+            status.setText(f"running on {getattr(self, '_rs_host', '')}:{getattr(self, '_rs_port', '')}"
+                           if running else 'stopped')
+            start_btn.setEnabled(not running)
+            stop_btn.setEnabled(running)
+            for w in (host_edit, port_edit, token_edit, gen_btn):
+                w.setEnabled(not running)
+
+        def do_start():
+            try:
+                port = int(port_edit.text())
+            except ValueError:
+                QtWidgets.QMessageBox.warning(dlg, 'Remote Scripting', 'Port must be a number.')
+                return
+            host = host_edit.text().strip() or '127.0.0.1'
+            token = token_edit.text().strip()
+            if host not in ('127.0.0.1', 'localhost') and not token:
+                if QtWidgets.QMessageBox.question(
+                        dlg, 'No token',
+                        'Exposing arbitrary-Python execution on the network with no token lets any '
+                        'machine on the LAN run code on this PC. Start anyway?',
+                        QtWidgets.QMessageBox.Yes | QtWidgets.QMessageBox.No) != QtWidgets.QMessageBox.Yes:
+                    return
+            self._rs_host, self._rs_port, self._rs_token = host, port, token
+            # Do NOT assume success here: the Core binds the socket on its own
+            # thread and may fail (port in use). on_remote_scripting_started sets
+            # the running state and refreshes the dialog from the real outcome.
+            self.sig_start_remote_scripting.emit(host, port, token)
+
+        def do_stop():
+            self.sig_stop_remote_scripting.emit()
+            self._remote_scripting_running = False
+            refresh()
+
+        start_btn.clicked.connect(do_start)
+        stop_btn.clicked.connect(do_stop)
+        # Let the started-signal handler refresh this dialog while it is open
+        # (a modal exec_ still pumps queued cross-thread signals).
+        self._rs_refresh = refresh
+        refresh()
+        dlg.exec_()
+        self._rs_refresh = None
 
     def choose_snap_folder(self):
         path = QtWidgets.QFileDialog.getExistingDirectory(self, 'Open csv File', self.state['snap_folder'])

--- a/mesoSPIM/src/mesoSPIM_RemoteScripting.py
+++ b/mesoSPIM/src/mesoSPIM_RemoteScripting.py
@@ -1,0 +1,312 @@
+"""
+mesoSPIM remote scripting server.
+=================================
+Exposes mesoSPIM's Script Window over a localhost TCP socket: an external process
+sends a Python script, it runs in the live ``mesoSPIM_Core`` context exactly as
+the Script Window runs it (via the existing ``Core.execute_script``), and the
+captured console output (stdout + stderr) is sent back. That is the whole
+feature -- text in, console text out. No command vocabulary, no data format: a
+client scripts the microscope with the full mesoSPIM Python API and prints
+whatever it wants to get back.
+
+    SECURITY. A script runs as ARBITRARY PYTHON on the acquisition PC (it can
+    touch the filesystem, not only the scope). So the server is OFF by default,
+    started by an operator from the GUI (Tools -> Remote Scripting...), binds to
+    ``127.0.0.1`` unless changed, and can require a shared ``token`` (the client
+    must present it before any script runs). The token is compared in constant
+    time. NOTE: this is plain TCP -- the token is sent in clear text, so it is a
+    gate against casual access on a trusted LAN, not protection against a network
+    sniffer. For untrusted networks, tunnel it (SSH/VPN).
+
+    BLOCKING. A script runs synchronously on the Core's thread via
+    ``Core.execute_script``, exactly as the Script Window does -- so the GUI is
+    unresponsive while a script runs. Keep injected scripts short (start work and
+    return; poll for completion in separate calls) rather than sleeping inside
+    one long-running script.
+
+Wire protocol (line-length-framed, UTF-8):
+
+    request  =  b"<decimal-byte-count>\\n" + <payload bytes>
+    reply    =  same framing
+
+If a token is configured, the FIRST frame a client sends must be the token; the
+server replies with a one-frame ``"OK"`` or ``"AUTH-FAILED"`` (and closes on
+failure). Every frame after that (or every frame, if no token) is a script; the
+reply frame is the captured console output.
+
+The framing and auth logic (:func:`frame`, :class:`FrameDecoder`,
+:class:`AuthGate`) is kept socket-free so it unit-tests without a running Qt
+event loop; ``QtNetwork`` is imported lazily by the server itself.
+
+Author: Thom de Hoog (ZMB, University of Zurich). License: GPL-3.0 (part of
+mesoSPIM-control; it uses the GPL Core API).
+"""
+
+import hmac
+import io
+import logging
+import sys
+import threading
+import traceback
+
+logger = logging.getLogger(__name__)
+
+ENCODING = "utf-8"
+MAX_FRAME_BYTES = 16 * 1024 * 1024  # guard against a client that never frames
+
+
+class FramingError(ValueError):
+    """A frame's length prefix was not a decimal byte count."""
+
+
+def frame(payload):
+    """Length-prefix a payload for the wire: ``b"<len>\\n" + payload``."""
+    if isinstance(payload, str):
+        payload = payload.encode(ENCODING)
+    return str(len(payload)).encode("ascii") + b"\n" + payload
+
+
+class FrameDecoder:
+    """Incremental parser for length-prefixed frames (socket-free, so testable).
+
+    Feed it received bytes with :meth:`feed`, then iterate :meth:`frames` for the
+    complete payloads buffered so far. Raises :class:`FramingError` on a
+    non-integer length line. :attr:`buffered` is the unconsumed byte count, so
+    the caller can cap it against a client that never frames.
+    """
+
+    def __init__(self):
+        self._buf = b""
+
+    def feed(self, data):
+        self._buf += bytes(data)
+
+    @property
+    def buffered(self):
+        return len(self._buf)
+
+    def frames(self):
+        """Yield each complete payload (bytes) buffered so far, consuming it."""
+        while b"\n" in self._buf:
+            head, _, rest = self._buf.partition(b"\n")
+            try:
+                length = int(head)
+            except ValueError as exc:
+                raise FramingError("expected '<byte-count>\\n<payload>'") from exc
+            if len(rest) < length:
+                return  # payload not fully arrived yet
+            self._buf = rest[length:]
+            yield rest[:length]
+
+
+class AuthGate:
+    """Constant-time shared-token gate for the first frame.
+
+    :attr:`passed` is True from the start when no token is configured. :meth:`check`
+    compares the supplied first frame against the token in constant time, over
+    UTF-8 bytes so a non-ASCII token works (``hmac.compare_digest`` refuses to
+    compare a ``str`` containing non-ASCII).
+    """
+
+    def __init__(self, token=None):
+        self._token = token or None
+        self.passed = self._token is None
+
+    @property
+    def required(self):
+        return self._token is not None
+
+    def check(self, supplied):
+        """True if *supplied* matches the token; sets :attr:`passed` on success."""
+        if isinstance(supplied, str):
+            supplied = supplied.encode(ENCODING)
+        ok = hmac.compare_digest(supplied, str(self._token).encode(ENCODING))
+        if ok:
+            self.passed = True
+        return ok
+
+
+class _ThreadTee:
+    """A stdout/stderr stand-in that always writes through to the real stream and,
+    additionally, to a per-thread capture buffer when one is registered for the
+    calling thread.
+
+    This lets the server capture a script's own console output for the reply
+    *without* hijacking the process-wide stream: a script runs alone on the Core
+    thread, so only that thread has a buffer registered, and every other thread's
+    output still reaches the real console untouched.
+    """
+
+    def __init__(self, real):
+        self._real = real
+        self._buffers = {}
+
+    def register(self, buf):
+        self._buffers[threading.get_ident()] = buf
+
+    def unregister(self):
+        self._buffers.pop(threading.get_ident(), None)
+
+    def write(self, text):
+        buf = self._buffers.get(threading.get_ident())
+        if buf is not None:
+            buf.write(text)
+        return self._real.write(text)
+
+    def flush(self):
+        self._real.flush()
+
+    def __getattr__(self, name):  # delegate isatty/encoding/... to the real stream
+        return getattr(self._real, name)
+
+
+class RemoteScriptingServer:
+    """A localhost TCP server that runs received scripts in the Core context.
+
+    Signal-driven (QTcpServer + readyRead), so it lives on the Core's event loop
+    without blocking it while idle. One client at a time -- a new connection
+    preempts a stale one, so a crashed client's half-open socket can never hold
+    the server hostage. Parented to the Core so Qt owns its lifetime.
+
+    Raises ``RuntimeError`` if the socket cannot bind (e.g. the port is in use);
+    the caller reports that to the operator rather than showing a false "running".
+    """
+
+    def __init__(self, core, host="127.0.0.1", port=42000, token=None):
+        from PyQt5 import QtNetwork
+
+        self.core = core
+        self._token = token or None
+        # QHostAddress does not resolve hostnames; map the common alias.
+        bind_host = "127.0.0.1" if host in ("localhost", "") else host
+        self._server = QtNetwork.QTcpServer(core)
+        if not self._server.listen(QtNetwork.QHostAddress(bind_host), int(port)):
+            raise RuntimeError(
+                f"cannot listen on {host}:{port}: {self._server.errorString()}"
+            )
+        self._host, self._port = bind_host, int(port)
+        self._server.newConnection.connect(self._on_new_connection)
+        self._conn = None
+        self._decoder = FrameDecoder()
+        self._auth = AuthGate(self._token)
+        # Tee sys.stdout/stderr so a script's own output can be captured per-thread
+        # (see _ThreadTee / _run_script) without swapping the process-wide stream
+        # out from under the other threads. Restored in stop().
+        self._real_stdout, self._real_stderr = sys.stdout, sys.stderr
+        self._out_tee = _ThreadTee(sys.stdout)
+        self._err_tee = _ThreadTee(sys.stderr)
+        sys.stdout, sys.stderr = self._out_tee, self._err_tee
+        logger.info(
+            "Remote scripting listening on %s:%d (token %s)",
+            self._host,
+            self._port,
+            "required" if self._token else "off",
+        )
+
+    # -- connection lifecycle ------------------------------------------------
+
+    def _on_new_connection(self):
+        conn = self._server.nextPendingConnection()
+        if self._conn is not None:
+            self._drop_client(self._conn)
+        self._conn = conn
+        self._decoder = FrameDecoder()
+        self._auth = AuthGate(self._token)
+        conn.readyRead.connect(self._on_ready_read)
+        conn.disconnected.connect(lambda c=conn: self._on_disconnected(c))
+
+    def _on_disconnected(self, conn):
+        if conn is self._conn:
+            self._conn = None
+        # Qt may already have reclaimed the C++ socket by the time the queued
+        # ``disconnected`` fires; calling deleteLater() on it then raises
+        # RuntimeError. A client dropping MUST NOT crash mesoSPIM, so guard it.
+        try:
+            conn.deleteLater()
+        except RuntimeError:
+            pass
+
+    def _drop_client(self, conn):
+        if conn is self._conn:
+            self._conn = None
+        try:
+            conn.disconnected.disconnect()
+        except (TypeError, RuntimeError):
+            pass  # no slots were connected, or the socket is already gone
+        try:
+            conn.disconnectFromHost()
+            conn.deleteLater()
+        except RuntimeError:
+            pass  # already reclaimed by Qt
+
+    # -- framing / dispatch --------------------------------------------------
+
+    def _on_ready_read(self):
+        if self._conn is None:
+            return
+        self._decoder.feed(self._conn.readAll())
+        if self._decoder.buffered > MAX_FRAME_BYTES:
+            self._close("frame too large")
+            return
+        try:
+            for payload in self._decoder.frames():
+                self._handle(payload.decode(ENCODING, "replace"))
+                if self._conn is None:
+                    return  # a rejected/closed client: stop processing its frames
+        except FramingError as exc:
+            self._send(f"framing error: {exc}")
+            self._close("framing error")
+
+    def _send(self, text):
+        if self._conn is None:
+            return
+        self._conn.write(frame(text))
+        self._conn.flush()
+
+    def _close(self, _reason=""):
+        if self._conn is not None:
+            self._conn.disconnectFromHost()
+            self._conn = None  # _on_disconnected still deleteLater()s it
+
+    def _handle(self, message):
+        # First frame is the token when one is configured.
+        if not self._auth.passed:
+            if self._auth.check(message):
+                self._send("OK")
+            else:
+                self._send("AUTH-FAILED")
+                self._close("auth failed")
+            return
+        self._send(self._run_script(message))
+
+    def _run_script(self, script):
+        """Run ``script`` via the existing Core.execute_script, capturing its own
+        console output for the reply.
+
+        execute_script runs exec() in the Core context (self == Core) and prints
+        any traceback. A script runs alone on the Core thread (execute_script blocks
+        it), so we register a capture buffer for THIS thread on the tees installed
+        in __init__ -- capturing the script's stdout/stderr while other threads'
+        output keeps flowing only to the real console. We never swap the
+        process-wide stream out from under them.
+        """
+        buf = io.StringIO()
+        self._out_tee.register(buf)
+        self._err_tee.register(buf)
+        try:
+            self.core.execute_script(script)
+        except Exception:  # execute_script catches script errors; belt-and-suspenders
+            buf.write(traceback.format_exc())
+        finally:
+            self._out_tee.unregister()
+            self._err_tee.unregister()
+        return buf.getvalue()
+
+    def stop(self):
+        if self._conn is not None:
+            self._drop_client(self._conn)
+        self._server.close()
+        # Restore the real stdout/stderr we teed in __init__.
+        if getattr(self, "_real_stdout", None) is not None:
+            sys.stdout, sys.stderr = self._real_stdout, self._real_stderr
+        logger.info("Remote scripting stopped")


### PR DESCRIPTION
## What this adds

mesoSPIM-control has no external control interface — everything runs in-process in the Qt event loop. The Script Window already runs Python in the live Core (`self == Core`); this PR makes that reachable from another process over a localhost socket, so external tools can script the microscope with the full mesoSPIM Python API. **Text in, console text out** — no command vocabulary, no data format.

## Why it's this small

It reuses the **existing, unmodified** `Core.execute_script`. Everything opinionated (a command set, structured results) lives in the *client*, injected as a script — so there's nothing new for mesoSPIM to maintain.

## Files (3 files, +480)

- **`mesoSPIM_RemoteScripting.py`** (new): a signal-driven `QTcpServer`. For each received script it runs `Core.execute_script` and returns its console output, captured **per-thread** so it never swaps the process-wide `stdout`/`stderr` out from under other threads. Length-framed UTF-8; framing + the token gate are socket-free helpers (`frame` / `FrameDecoder` / `AuthGate`) with Qt-free unit tests; constant-time token compare over UTF-8 bytes. A new client preempts a stale one, and a dropped/crashed client's teardown is guarded, so a misbehaving client can neither wedge nor crash the server.
- **`mesoSPIM_Core.py`** (+37): `start_remote_scripting(host, port, token)` / `stop_remote_scripting()` slots, invoked via a **queued** connection so the server lives on the Core thread (where `execute_script` runs), plus a `sig_remote_scripting_started(ok, message)` signal so a bind failure is reported instead of shown as a false "running".
- **`mesoSPIM_MainWindow.py`** (+131): a **Tools → Remote Scripting…** menu entry with a Start/Stop dialog (host / port / token + generator); reflects the real start outcome; stops on app close.

## Security — this is remote code execution, handled deliberately

- **Opt-in**: the menu appears only when the config sets `enable_remote_scripting = True` — an unmodified install cannot start it.
- **Off by default** even then; started by an operator from the GUI.
- **Secure by default when started**: binds `127.0.0.1`, the dialog pre-fills a fresh token, and warns before any network bind without a token.
- Plain TCP — the token gates casual/accidental LAN access, it is **not** sniffer-proof (tunnel over SSH/VPN for untrusted networks). TLS is intentionally out of scope for this minimal PR.

## Validation

Ran the real app in `-D` demo mode (all Demo backends, offscreen Qt on Windows) on both **v1.20.0** and this **`release/candidate-py312`** branch: a client authenticates (incl. a non-ASCII token), reads state, drives the demo stage (`self.move_absolute`), runs an acquisition that writes a file, gets structured output via `print(json.dumps(...))`, and sees a raising script's traceback returned as text (no crash). `execute_script` is unchanged, so there's no behavior change for existing users.

Happy to adjust the naming, add a config-file defaults block, or a CHANGELOG / docs entry as you prefer.
