### PR TITLE
Fixes Image Writer Timeout and Improves Performance

### DIFF
--- a/mesoSPIM/src/mesoSPIM_Core.py
+++ b/mesoSPIM/src/mesoSPIM_Core.py
@@ -271,17 +271,25 @@ class mesoSPIM_Core(QtCore.QObject):
         so that stop signals and GUI updates are still delivered.
 
         Args:
-            timeout_s (float): Maximum time to wait in seconds before giving up.
+            timeout_s (float): Number of seconds to wait before printing a warning
         """
+        total_time_elapsed = 0
+        start_time = time.time()
         deadline = time.time() + timeout_s
         while not (self._camera_end_done and self._writer_end_done):
             QtWidgets.QApplication.processEvents(QtCore.QEventLoop.AllEvents, 50)
+
             if time.time() > deadline:
+                total_time_elapsed = round(time.time() - start_time, 2)
                 logger.warning(
-                    '_wait_for_end_image_series timed out after %.1f s '
+                    '_wait_for_end_image_series %.1f s warning'
                     '(camera_done=%s, writer_done=%s)',
-                    timeout_s, self._camera_end_done, self._writer_end_done)
-                break
+                    total_time_elapsed, self._camera_end_done, self._writer_end_done)
+
+                # Do NOT continue to the next acquisition while writer is busy.
+                # Reset the warning timer and continue waiting.
+                deadline = time.time() + timeout_s
+
             time.sleep(0.01)
 
     @QtCore.pyqtSlot(dict)

--- a/mesoSPIM/src/mesoSPIM_ImageWriter.py
+++ b/mesoSPIM/src/mesoSPIM_ImageWriter.py
@@ -310,16 +310,17 @@ class mesoSPIM_ImageWriter(QtCore.QObject):
 
         total_ms = (time.perf_counter() - total_start) * 1000
 
-        logger.info(
-            "image_to_disk breakdown: total=%.1f ms "
-            "status=%.1f ms metadata=%.1f ms "
-            "writer=%.1f ms MAX=%.1f ms",
-            total_ms,
-            status_ms,
-            metadata_ms,
-            writer_ms,
-            max_ms,
-        )
+        if total_ms > 20:
+            logger.info(
+                "image_to_disk breakdown: total=%.1f ms "
+                "status=%.1f ms metadata=%.1f ms "
+                "writer=%.1f ms MAX=%.1f ms",
+                total_ms,
+                status_ms,
+                metadata_ms,
+                writer_ms,
+                max_ms,
+            )
 
         logger.debug('image_to_disk() ended')
 

--- a/mesoSPIM/src/mesoSPIM_ImageWriter.py
+++ b/mesoSPIM/src/mesoSPIM_ImageWriter.py
@@ -241,47 +241,119 @@ class mesoSPIM_ImageWriter(QtCore.QObject):
                 self.image_to_disk(acq, acq_list, image)
         else:
             logger.debug('self.running_flag = False, no images written')
-    
+
     @timed
     @log_cpu_core
     def image_to_disk(self, acq, acq_list, image):
-        """Write a single pre-transposed frame to the open writer backend.
-
-        Args:
-            acq (Acquisition): Active acquisition descriptor (provides zoom, z_step …).
-            acq_list (AcquisitionList): Full list (provides tile/channel/rotation indices).
-            image (np.ndarray): 2-D ``uint16`` array already transposed by the caller.
-        """
         logger.debug('image_to_disk() started')
+
+        total_start = time.perf_counter()
+
+        # Status update
+        t0 = time.perf_counter()
         if self.cur_image_counter % 5 == 0:
             self.parent.sig_status_message.emit('Writing to disk...')
+        status_ms = (time.perf_counter() - t0) * 1000
 
-        xy_res = (1. / self.cfg.pixelsize[acq['zoom']], 1. / self.cfg.pixelsize[acq['zoom']])
+        # Metadata / WriteImage construction
+        t0 = time.perf_counter()
+
+        xy_res = (
+            1. / self.cfg.pixelsize[acq['zoom']],
+            1. / self.cfg.pixelsize[acq['zoom']]
+        )
 
         write = WriteImage(
-            image = image,
-            current_image_counter = self.cur_image_counter,
+            image=image,
+            current_image_counter=self.cur_image_counter,
             tile_number=acq_list.get_tile_index(acq),
             laser=acq_list.find_value_index(acq['laser'], 'laser'),
-            shutter=acq_list.find_value_index(acq['shutterconfig'], 'shutterconfig'),
+            shutter=acq_list.find_value_index(
+                acq['shutterconfig'], 'shutterconfig'
+            ),
             rot=acq_list.find_value_index(acq['rot'], 'rot'),
             x_res=xy_res,
             y_res=xy_res,
             z_res=acq['z_step'],
             unit='microns',
-            acq = acq,
-            acq_list = acq_list,
+            acq=acq,
+            acq_list=acq_list,
         )
 
+        metadata_ms = (time.perf_counter() - t0) * 1000
+
+        # MP writer
+        t0 = time.perf_counter()
         self.writer.write_frame(write)
+        writer_ms = (time.perf_counter() - t0) * 1000
 
-        # Place holder prior to image processing plugins
+        # MAX projection
+        t0 = time.perf_counter()
         if acq['processing'] == 'MAX':
-            np.maximum(self.mip_image, image, out=self.mip_image)
-
+            np.maximum(
+                self.mip_image,
+                image,
+                out=self.mip_image
+            )
+        max_ms = (time.perf_counter() - t0) * 1000
 
         self.cur_image_counter += 1
+
+        total_ms = (time.perf_counter() - total_start) * 1000
+
+        logger.info(
+            "image_to_disk breakdown: total=%.1f ms "
+            "status=%.1f ms metadata=%.1f ms "
+            "writer=%.1f ms MAX=%.1f ms",
+            total_ms,
+            status_ms,
+            metadata_ms,
+            writer_ms,
+            max_ms,
+        )
+
         logger.debug('image_to_disk() ended')
+
+    # @timed
+    # @log_cpu_core
+    # def image_to_disk(self, acq, acq_list, image):
+    #     """Write a single pre-transposed frame to the open writer backend.
+    #
+    #     Args:
+    #         acq (Acquisition): Active acquisition descriptor (provides zoom, z_step …).
+    #         acq_list (AcquisitionList): Full list (provides tile/channel/rotation indices).
+    #         image (np.ndarray): 2-D ``uint16`` array already transposed by the caller.
+    #     """
+    #     logger.debug('image_to_disk() started')
+    #     if self.cur_image_counter % 5 == 0:
+    #         self.parent.sig_status_message.emit('Writing to disk...')
+    #
+    #     xy_res = (1. / self.cfg.pixelsize[acq['zoom']], 1. / self.cfg.pixelsize[acq['zoom']])
+    #
+    #     write = WriteImage(
+    #         image = image,
+    #         current_image_counter = self.cur_image_counter,
+    #         tile_number=acq_list.get_tile_index(acq),
+    #         laser=acq_list.find_value_index(acq['laser'], 'laser'),
+    #         shutter=acq_list.find_value_index(acq['shutterconfig'], 'shutterconfig'),
+    #         rot=acq_list.find_value_index(acq['rot'], 'rot'),
+    #         x_res=xy_res,
+    #         y_res=xy_res,
+    #         z_res=acq['z_step'],
+    #         unit='microns',
+    #         acq = acq,
+    #         acq_list = acq_list,
+    #     )
+    #
+    #     self.writer.write_frame(write)
+    #
+    #     # Place holder prior to image processing plugins
+    #     if acq['processing'] == 'MAX':
+    #         np.maximum(self.mip_image, image, out=self.mip_image)
+    #
+    #
+    #     self.cur_image_counter += 1
+    #     logger.debug('image_to_disk() ended')
 
     @QtCore.pyqtSlot()
     def abort_writing(self):

--- a/mesoSPIM/src/mesoSPIM_ImageWriter.py
+++ b/mesoSPIM/src/mesoSPIM_ImageWriter.py
@@ -219,7 +219,7 @@ class mesoSPIM_ImageWriter(QtCore.QObject):
         # Place holder prior to image processing plugins
         if acq['processing'] == 'MAX':
             self.tiff_mip_writer = tifffile.TiffWriter(self.MIP_path, imagej=True)
-            self.mip_image = np.zeros((self.x_pixels, self.y_pixels), 'uint16')
+            self.mip_image = None
 
         self.cur_image_counter = 0
         self.abort_flag = False
@@ -237,7 +237,7 @@ class mesoSPIM_ImageWriter(QtCore.QObject):
         if self.running_flag:
             while len(self.frame_queue) > 0:
                 logger.debug('image queue length: ' + str(len(self.frame_queue)))
-                image = self.frame_queue.popleft().T[::-1]
+                image = self.frame_queue.popleft() # Do not transpose so that downstream operations like max are more efficient
                 self.image_to_disk(acq, acq_list, image)
         else:
             logger.debug('self.running_flag = False, no images written')
@@ -264,7 +264,10 @@ class mesoSPIM_ImageWriter(QtCore.QObject):
         )
 
         write = WriteImage(
-            image=image,
+            # Transform image before sending to writer, this can cause performance issues downstream
+            # if memory copies are required like with copies to the ring buffer for MP OME-Zarr writer
+            # Need to consider how to make this more efficient to increase MP Writer Performance
+            image=image.T[::-1],
             current_image_counter=self.cur_image_counter,
             tile_number=acq_list.get_tile_index(acq),
             laser=acq_list.find_value_index(acq['laser'], 'laser'),
@@ -290,6 +293,12 @@ class mesoSPIM_ImageWriter(QtCore.QObject):
         # MAX projection
         t0 = time.perf_counter()
         if acq['processing'] == 'MAX':
+            # Allocate RAM for MIP
+            if self.mip_image is None:
+                self.mip_image = np.zeros_like(image)
+
+            # Max is done on a non-transformed image to keep memory operations efficient
+            # Need to transform the final image right before saving
             np.maximum(
                 self.mip_image,
                 image,
@@ -313,47 +322,6 @@ class mesoSPIM_ImageWriter(QtCore.QObject):
         )
 
         logger.debug('image_to_disk() ended')
-
-    # @timed
-    # @log_cpu_core
-    # def image_to_disk(self, acq, acq_list, image):
-    #     """Write a single pre-transposed frame to the open writer backend.
-    #
-    #     Args:
-    #         acq (Acquisition): Active acquisition descriptor (provides zoom, z_step …).
-    #         acq_list (AcquisitionList): Full list (provides tile/channel/rotation indices).
-    #         image (np.ndarray): 2-D ``uint16`` array already transposed by the caller.
-    #     """
-    #     logger.debug('image_to_disk() started')
-    #     if self.cur_image_counter % 5 == 0:
-    #         self.parent.sig_status_message.emit('Writing to disk...')
-    #
-    #     xy_res = (1. / self.cfg.pixelsize[acq['zoom']], 1. / self.cfg.pixelsize[acq['zoom']])
-    #
-    #     write = WriteImage(
-    #         image = image,
-    #         current_image_counter = self.cur_image_counter,
-    #         tile_number=acq_list.get_tile_index(acq),
-    #         laser=acq_list.find_value_index(acq['laser'], 'laser'),
-    #         shutter=acq_list.find_value_index(acq['shutterconfig'], 'shutterconfig'),
-    #         rot=acq_list.find_value_index(acq['rot'], 'rot'),
-    #         x_res=xy_res,
-    #         y_res=xy_res,
-    #         z_res=acq['z_step'],
-    #         unit='microns',
-    #         acq = acq,
-    #         acq_list = acq_list,
-    #     )
-    #
-    #     self.writer.write_frame(write)
-    #
-    #     # Place holder prior to image processing plugins
-    #     if acq['processing'] == 'MAX':
-    #         np.maximum(self.mip_image, image, out=self.mip_image)
-    #
-    #
-    #     self.cur_image_counter += 1
-    #     logger.debug('image_to_disk() ended')
 
     @QtCore.pyqtSlot()
     def abort_writing(self):
@@ -408,7 +376,7 @@ class mesoSPIM_ImageWriter(QtCore.QObject):
         # Place holder prior to image processing plugins
         if acq['processing'] == 'MAX':
             try:
-                self.tiff_mip_writer.write(self.mip_image)
+                self.tiff_mip_writer.write(self.mip_image.T[::-1]) # Transform image before saving
                 self.tiff_mip_writer.close()
             except Exception as e:
                 logger.error(f'{e}')

--- a/mesoSPIM/src/mesoSPIM_ImageWriter.py
+++ b/mesoSPIM/src/mesoSPIM_ImageWriter.py
@@ -362,7 +362,7 @@ class mesoSPIM_ImageWriter(QtCore.QObject):
         if self.running_flag:
             while len(self.frame_queue) > 0:
                 logger.debug(f'end_acquisition: flushing {len(self.frame_queue)} remaining frame(s)')
-                image = self.frame_queue.popleft().T[::-1]
+                image = self.frame_queue.popleft() # Do not transpose so that downstream operations like max are more efficient
                 self.image_to_disk(acq, acq_list, image)
 
             if self.cur_image_counter != self.max_frame:

--- a/mesoSPIM/src/plugins/ImageWriters/OmeZarrWriterMP.py
+++ b/mesoSPIM/src/plugins/ImageWriters/OmeZarrWriterMP.py
@@ -5,6 +5,7 @@ logger = logging.getLogger(__name__)
 import numpy as np
 from typing import Any, Dict, Iterable, Optional, Protocol, runtime_checkable, Tuple, List, Union
 import sys
+import time
 
 # Setup multiprocessing with 'spawn' method
 import multiprocessing as mp
@@ -392,15 +393,39 @@ class OMEZarrWriterMP(ImageWriter):
             f"Expected frame shape {self._frame_shape}, got {frame.shape}"
         )
 
+        total_start = time.perf_counter()
+
         # Get a free slot (blocks if all slots are in use -> back-pressure)
+        t0 = time.perf_counter()
         slot = self._free_q.get()
+        wait_ms = (time.perf_counter() - t0) * 1000
 
         # Copy the frame into shared memory
+        t0 = time.perf_counter()
         np.copyto(self._ring[slot], frame)
-        # self._ring[slot] = frame
+        copy_ms = (time.perf_counter() - t0) * 1000
 
         # Tell writer process which slot to read
+        t0 = time.perf_counter()
         self._work_q.put(slot)
+        put_ms = (time.perf_counter() - t0) * 1000
+
+        total_ms = (time.perf_counter() - total_start) * 1000
+
+        if total_ms > 20:
+            logger.info(
+                "MP handoff: total=%.1f ms "
+                "free_slot_wait=%.1f ms "
+                "copy=%.1f ms "
+                "queue_put=%.1f ms "
+                "C_contiguous=%s strides=%s",
+                total_ms,
+                wait_ms,
+                copy_ms,
+                put_ms,
+                frame.flags['C_CONTIGUOUS'],
+                frame.strides
+            )
 
     def finalize(self, finalize_image: FinalizeImage) -> None:
         # Tell this tile's writer process to finish


### PR DESCRIPTION
1) Fixes a bug where a crash would occur at the end of a tile of the MP OME-Zarr writer took longer than 30 seconds to ingest all of the images from the camera queue.  Now there is no limit and logs are generated at 30 sec intervals to document.

2) Improves the performance of the MAX intensity projection >30X so that the camera queue can be emptied more quickly. Reduces the latency for each frame from ~20-60ms to ~2ms.

3) The issue described in point 2 along with the latency introduced by copying each frame into the ring buffer (not fixed) for the MP OME-Zarr writer sometimes caused the completion of a tile to go longer than 30 seconds after the last frame was acquired causing the crash noted in point 1.

ToDo: Explore performance improvements for copying frames into the ring buffer for MP OME-Zarr Writer. Note: This only applies to MP OME-Zarr writer.

AI Summary of changes:

### Key Changes:
*   **Ensures Image Writer Completion:** Modifies the image series end-waiting logic (`_wait_for_end_image_series`) to continuously monitor the camera and writer completion status. Instead of timing out and potentially aborting, the system now logs warnings at regular intervals and waits indefinitely until all writing tasks are finalized, preventing data loss and ensuring full acquisition.
*   **Optimizes MAX Projection Efficiency:** Enhances the efficiency of Maximum Intensity Projection (MIP) by performing `np.maximum` operations on the raw, non-transposed image data. Image transposition is now deferred to just before data is written to disk or the final MIP is saved, reducing unnecessary memory copies and improving processing speed.
*   **Adds Detailed Performance Logging:** Integrates comprehensive timing logs within the `image_to_disk` function and the multiprocessing ring buffer handoff in the MP OME-Zarr writer. These logs provide granular insights into the performance breakdown of image processing, metadata generation, writing, and inter-process communication.
*   **Updates timeout parameter description** for clarity in `_wait_for_end_image_series`.

### Checklist:
*   [x] Changes the behaviour of the application
*   [ ] Introduces a new feature
*   [x] Fixes a bug
*   [ ] Breaks API compatibility
*   [ ] Includes tests
*   [x] Updates documentation (code comments/docstrings)
*   [ ] Updates release notes