### PR TITLE
Fixes MP OME-Zarr Writer Shutdown Hangs

### DIFF
--- a/mesoSPIM/src/mesoSPIM_Core.py
+++ b/mesoSPIM/src/mesoSPIM_Core.py
@@ -271,17 +271,25 @@ class mesoSPIM_Core(QtCore.QObject):
         so that stop signals and GUI updates are still delivered.
 
         Args:
-            timeout_s (float): Maximum time to wait in seconds before giving up.
+            timeout_s (float): Number of seconds to wait before printing a warning
         """
+        total_time_elapsed = 0
+        start_time = time.time()
         deadline = time.time() + timeout_s
         while not (self._camera_end_done and self._writer_end_done):
             QtWidgets.QApplication.processEvents(QtCore.QEventLoop.AllEvents, 50)
+
             if time.time() > deadline:
+                total_time_elapsed = round(time.time() - start_time, 2)
                 logger.warning(
-                    '_wait_for_end_image_series timed out after %.1f s '
+                    '_wait_for_end_image_series %.1f s warning'
                     '(camera_done=%s, writer_done=%s)',
-                    timeout_s, self._camera_end_done, self._writer_end_done)
-                break
+                    total_time_elapsed, self._camera_end_done, self._writer_end_done)
+
+                # Do NOT continue to the next acquisition while writer is busy.
+                # Reset the warning timer and continue waiting.
+                deadline = time.time() + timeout_s
+
             time.sleep(0.01)
 
     @QtCore.pyqtSlot(dict)

--- a/mesoSPIM/src/mesoSPIM_ImageWriter.py
+++ b/mesoSPIM/src/mesoSPIM_ImageWriter.py
@@ -310,16 +310,17 @@ class mesoSPIM_ImageWriter(QtCore.QObject):
 
         total_ms = (time.perf_counter() - total_start) * 1000
 
-        logger.info(
-            "image_to_disk breakdown: total=%.1f ms "
-            "status=%.1f ms metadata=%.1f ms "
-            "writer=%.1f ms MAX=%.1f ms",
-            total_ms,
-            status_ms,
-            metadata_ms,
-            writer_ms,
-            max_ms,
-        )
+        if total_ms > 20:
+            logger.info(
+                "image_to_disk breakdown: total=%.1f ms "
+                "status=%.1f ms metadata=%.1f ms "
+                "writer=%.1f ms MAX=%.1f ms",
+                total_ms,
+                status_ms,
+                metadata_ms,
+                writer_ms,
+                max_ms,
+            )
 
         logger.debug('image_to_disk() ended')
 

--- a/mesoSPIM/src/mesoSPIM_ImageWriter.py
+++ b/mesoSPIM/src/mesoSPIM_ImageWriter.py
@@ -241,47 +241,119 @@ class mesoSPIM_ImageWriter(QtCore.QObject):
                 self.image_to_disk(acq, acq_list, image)
         else:
             logger.debug('self.running_flag = False, no images written')
-    
+
     @timed
     @log_cpu_core
     def image_to_disk(self, acq, acq_list, image):
-        """Write a single pre-transposed frame to the open writer backend.
-
-        Args:
-            acq (Acquisition): Active acquisition descriptor (provides zoom, z_step …).
-            acq_list (AcquisitionList): Full list (provides tile/channel/rotation indices).
-            image (np.ndarray): 2-D ``uint16`` array already transposed by the caller.
-        """
         logger.debug('image_to_disk() started')
+
+        total_start = time.perf_counter()
+
+        # Status update
+        t0 = time.perf_counter()
         if self.cur_image_counter % 5 == 0:
             self.parent.sig_status_message.emit('Writing to disk...')
+        status_ms = (time.perf_counter() - t0) * 1000
 
-        xy_res = (1. / self.cfg.pixelsize[acq['zoom']], 1. / self.cfg.pixelsize[acq['zoom']])
+        # Metadata / WriteImage construction
+        t0 = time.perf_counter()
+
+        xy_res = (
+            1. / self.cfg.pixelsize[acq['zoom']],
+            1. / self.cfg.pixelsize[acq['zoom']]
+        )
 
         write = WriteImage(
-            image = image,
-            current_image_counter = self.cur_image_counter,
+            image=image,
+            current_image_counter=self.cur_image_counter,
             tile_number=acq_list.get_tile_index(acq),
             laser=acq_list.find_value_index(acq['laser'], 'laser'),
-            shutter=acq_list.find_value_index(acq['shutterconfig'], 'shutterconfig'),
+            shutter=acq_list.find_value_index(
+                acq['shutterconfig'], 'shutterconfig'
+            ),
             rot=acq_list.find_value_index(acq['rot'], 'rot'),
             x_res=xy_res,
             y_res=xy_res,
             z_res=acq['z_step'],
             unit='microns',
-            acq = acq,
-            acq_list = acq_list,
+            acq=acq,
+            acq_list=acq_list,
         )
 
+        metadata_ms = (time.perf_counter() - t0) * 1000
+
+        # MP writer
+        t0 = time.perf_counter()
         self.writer.write_frame(write)
+        writer_ms = (time.perf_counter() - t0) * 1000
 
-        # Place holder prior to image processing plugins
+        # MAX projection
+        t0 = time.perf_counter()
         if acq['processing'] == 'MAX':
-            np.maximum(self.mip_image, image, out=self.mip_image)
-
+            np.maximum(
+                self.mip_image,
+                image,
+                out=self.mip_image
+            )
+        max_ms = (time.perf_counter() - t0) * 1000
 
         self.cur_image_counter += 1
+
+        total_ms = (time.perf_counter() - total_start) * 1000
+
+        logger.info(
+            "image_to_disk breakdown: total=%.1f ms "
+            "status=%.1f ms metadata=%.1f ms "
+            "writer=%.1f ms MAX=%.1f ms",
+            total_ms,
+            status_ms,
+            metadata_ms,
+            writer_ms,
+            max_ms,
+        )
+
         logger.debug('image_to_disk() ended')
+
+    # @timed
+    # @log_cpu_core
+    # def image_to_disk(self, acq, acq_list, image):
+    #     """Write a single pre-transposed frame to the open writer backend.
+    #
+    #     Args:
+    #         acq (Acquisition): Active acquisition descriptor (provides zoom, z_step …).
+    #         acq_list (AcquisitionList): Full list (provides tile/channel/rotation indices).
+    #         image (np.ndarray): 2-D ``uint16`` array already transposed by the caller.
+    #     """
+    #     logger.debug('image_to_disk() started')
+    #     if self.cur_image_counter % 5 == 0:
+    #         self.parent.sig_status_message.emit('Writing to disk...')
+    #
+    #     xy_res = (1. / self.cfg.pixelsize[acq['zoom']], 1. / self.cfg.pixelsize[acq['zoom']])
+    #
+    #     write = WriteImage(
+    #         image = image,
+    #         current_image_counter = self.cur_image_counter,
+    #         tile_number=acq_list.get_tile_index(acq),
+    #         laser=acq_list.find_value_index(acq['laser'], 'laser'),
+    #         shutter=acq_list.find_value_index(acq['shutterconfig'], 'shutterconfig'),
+    #         rot=acq_list.find_value_index(acq['rot'], 'rot'),
+    #         x_res=xy_res,
+    #         y_res=xy_res,
+    #         z_res=acq['z_step'],
+    #         unit='microns',
+    #         acq = acq,
+    #         acq_list = acq_list,
+    #     )
+    #
+    #     self.writer.write_frame(write)
+    #
+    #     # Place holder prior to image processing plugins
+    #     if acq['processing'] == 'MAX':
+    #         np.maximum(self.mip_image, image, out=self.mip_image)
+    #
+    #
+    #     self.cur_image_counter += 1
+    #     logger.debug('image_to_disk() ended')
 
     @QtCore.pyqtSlot()
     def abort_writing(self):

--- a/mesoSPIM/src/mesoSPIM_ImageWriter.py
+++ b/mesoSPIM/src/mesoSPIM_ImageWriter.py
@@ -219,7 +219,7 @@ class mesoSPIM_ImageWriter(QtCore.QObject):
         # Place holder prior to image processing plugins
         if acq['processing'] == 'MAX':
             self.tiff_mip_writer = tifffile.TiffWriter(self.MIP_path, imagej=True)
-            self.mip_image = np.zeros((self.x_pixels, self.y_pixels), 'uint16')
+            self.mip_image = None
 
         self.cur_image_counter = 0
         self.abort_flag = False
@@ -237,7 +237,7 @@ class mesoSPIM_ImageWriter(QtCore.QObject):
         if self.running_flag:
             while len(self.frame_queue) > 0:
                 logger.debug('image queue length: ' + str(len(self.frame_queue)))
-                image = self.frame_queue.popleft().T[::-1]
+                image = self.frame_queue.popleft() # Do not transpose so that downstream operations like max are more efficient
                 self.image_to_disk(acq, acq_list, image)
         else:
             logger.debug('self.running_flag = False, no images written')
@@ -264,7 +264,10 @@ class mesoSPIM_ImageWriter(QtCore.QObject):
         )
 
         write = WriteImage(
-            image=image,
+            # Transform image before sending to writer, this can cause performance issues downstream
+            # if memory copies are required like with copies to the ring buffer for MP OME-Zarr writer
+            # Need to consider how to make this more efficient to increase MP Writer Performance
+            image=image.T[::-1],
             current_image_counter=self.cur_image_counter,
             tile_number=acq_list.get_tile_index(acq),
             laser=acq_list.find_value_index(acq['laser'], 'laser'),
@@ -290,6 +293,12 @@ class mesoSPIM_ImageWriter(QtCore.QObject):
         # MAX projection
         t0 = time.perf_counter()
         if acq['processing'] == 'MAX':
+            # Allocate RAM for MIP
+            if self.mip_image is None:
+                self.mip_image = np.zeros_like(image)
+
+            # Max is done on a non-transformed image to keep memory operations efficient
+            # Need to transform the final image right before saving
             np.maximum(
                 self.mip_image,
                 image,
@@ -313,47 +322,6 @@ class mesoSPIM_ImageWriter(QtCore.QObject):
         )
 
         logger.debug('image_to_disk() ended')
-
-    # @timed
-    # @log_cpu_core
-    # def image_to_disk(self, acq, acq_list, image):
-    #     """Write a single pre-transposed frame to the open writer backend.
-    #
-    #     Args:
-    #         acq (Acquisition): Active acquisition descriptor (provides zoom, z_step …).
-    #         acq_list (AcquisitionList): Full list (provides tile/channel/rotation indices).
-    #         image (np.ndarray): 2-D ``uint16`` array already transposed by the caller.
-    #     """
-    #     logger.debug('image_to_disk() started')
-    #     if self.cur_image_counter % 5 == 0:
-    #         self.parent.sig_status_message.emit('Writing to disk...')
-    #
-    #     xy_res = (1. / self.cfg.pixelsize[acq['zoom']], 1. / self.cfg.pixelsize[acq['zoom']])
-    #
-    #     write = WriteImage(
-    #         image = image,
-    #         current_image_counter = self.cur_image_counter,
-    #         tile_number=acq_list.get_tile_index(acq),
-    #         laser=acq_list.find_value_index(acq['laser'], 'laser'),
-    #         shutter=acq_list.find_value_index(acq['shutterconfig'], 'shutterconfig'),
-    #         rot=acq_list.find_value_index(acq['rot'], 'rot'),
-    #         x_res=xy_res,
-    #         y_res=xy_res,
-    #         z_res=acq['z_step'],
-    #         unit='microns',
-    #         acq = acq,
-    #         acq_list = acq_list,
-    #     )
-    #
-    #     self.writer.write_frame(write)
-    #
-    #     # Place holder prior to image processing plugins
-    #     if acq['processing'] == 'MAX':
-    #         np.maximum(self.mip_image, image, out=self.mip_image)
-    #
-    #
-    #     self.cur_image_counter += 1
-    #     logger.debug('image_to_disk() ended')
 
     @QtCore.pyqtSlot()
     def abort_writing(self):
@@ -408,7 +376,7 @@ class mesoSPIM_ImageWriter(QtCore.QObject):
         # Place holder prior to image processing plugins
         if acq['processing'] == 'MAX':
             try:
-                self.tiff_mip_writer.write(self.mip_image)
+                self.tiff_mip_writer.write(self.mip_image.T[::-1]) # Transform image before saving
                 self.tiff_mip_writer.close()
             except Exception as e:
                 logger.error(f'{e}')

--- a/mesoSPIM/src/mesoSPIM_ImageWriter.py
+++ b/mesoSPIM/src/mesoSPIM_ImageWriter.py
@@ -362,7 +362,7 @@ class mesoSPIM_ImageWriter(QtCore.QObject):
         if self.running_flag:
             while len(self.frame_queue) > 0:
                 logger.debug(f'end_acquisition: flushing {len(self.frame_queue)} remaining frame(s)')
-                image = self.frame_queue.popleft().T[::-1]
+                image = self.frame_queue.popleft() # Do not transpose so that downstream operations like max are more efficient
                 self.image_to_disk(acq, acq_list, image)
 
             if self.cur_image_counter != self.max_frame:

--- a/mesoSPIM/src/plugins/ImageWriters/OmeZarrWriterMP.py
+++ b/mesoSPIM/src/plugins/ImageWriters/OmeZarrWriterMP.py
@@ -428,10 +428,14 @@ class OMEZarrWriterMP(ImageWriter):
             )
 
     def finalize(self, finalize_image: FinalizeImage) -> None:
+
+        logger.info("MP finalize: ENTER")
         # Tell this tile's writer process to finish
         if self._work_q is not None:
             try:
+                logger.info("MP finalize: sending work_q sentinel")
                 self._work_q.put(None)
+                logger.info("MP finalize: work_q sentinel sent")
             except Exception:
                 logger.exception("Failed to send shutdown to writer process")
 
@@ -450,14 +454,25 @@ class OMEZarrWriterMP(ImageWriter):
             self._shm = None
             self._ring = None
 
+        logger.info("MP finalize: parent shm closed")
+
         # BigStitcher XML logic still happens here, but:
         acq = finalize_image.acq
         acq_list = finalize_image.acq_list
 
+        logger.info(
+            "MP finalize: last_acq=%s xml_writer=%s background_writers=%d",
+            acq == acq_list[-1],
+            self.xml_writer is not None,
+            len(self._background_writers),
+        )
+
         if self.xml_writer and acq == acq_list[-1]:
             # Before writing XML or returning at the very end of the experiment,
             # wait for all background writers and clean up their shared memory.
+            logger.info("MP finalize: waiting for background writers")
             self._wait_for_background_writers()
+            logger.info("MP finalize: background writers FINISHED")
 
             self.xml_writer.set_attribute_labels('channel', tuple(acq_list.get_unique_attr_list('laser')))
             self.xml_writer.set_attribute_labels('illumination', tuple(acq_list.get_unique_attr_list('shutterconfig')))
@@ -503,12 +518,28 @@ class OMEZarrWriterMP(ImageWriter):
         self.MIP_path = path.with_name('MAX_' + path.name + '.tif').as_posix()
 
     def _wait_for_background_writers(self):
-        """Wait for all tile writer processes to finish and clean shared memory."""
-        for proc, shm_name in self._background_writers:
-            try:
-                proc.join()
-            except Exception:
-                logger.exception("Error joining writer process")
+        for i, (proc, shm_name) in enumerate(self._background_writers):
+            start = time.time()
+
+            while proc.is_alive():
+                proc.join(timeout=30)
+
+                if proc.is_alive():
+                    logger.warning(
+                        "OME-Zarr writer process %d still alive after %.1f s "
+                        "(pid=%s, exitcode=%s)",
+                        i,
+                        time.time() - start,
+                        proc.pid,
+                        proc.exitcode,
+                    )
+
+            logger.info(
+                "OME-Zarr writer process %d exited after %.1f s, exitcode=%s",
+                i,
+                time.time() - start,
+                proc.exitcode,
+            )
 
             # Now its shm can be safely unlinked
             try:
@@ -521,5 +552,28 @@ class OMEZarrWriterMP(ImageWriter):
             except Exception:
                 logger.exception("Error cleaning shared memory for %s", shm_name)
 
-        # clear the list so we don't double-join/unlink
+            # clear the list so we don't double-join/unlink
         self._background_writers.clear()
+
+
+    # def _wait_for_background_writers(self):
+    #     """Wait for all tile writer processes to finish and clean shared memory."""
+    #     for proc, shm_name in self._background_writers:
+    #         try:
+    #             proc.join()
+    #         except Exception:
+    #             logger.exception("Error joining writer process")
+    #
+    #         # Now its shm can be safely unlinked
+    #         try:
+    #             shm = shared_memory.SharedMemory(name=shm_name)
+    #             shm.close()
+    #             shm.unlink()
+    #         except FileNotFoundError:
+    #             # Already cleaned or never created
+    #             pass
+    #         except Exception:
+    #             logger.exception("Error cleaning shared memory for %s", shm_name)
+    #
+    #     # clear the list so we don't double-join/unlink
+    #     self._background_writers.clear()

--- a/mesoSPIM/src/plugins/ImageWriters/OmeZarrWriterMP.py
+++ b/mesoSPIM/src/plugins/ImageWriters/OmeZarrWriterMP.py
@@ -5,6 +5,7 @@ logger = logging.getLogger(__name__)
 import numpy as np
 from typing import Any, Dict, Iterable, Optional, Protocol, runtime_checkable, Tuple, List, Union
 import sys
+import time
 
 # Setup multiprocessing with 'spawn' method
 import multiprocessing as mp
@@ -392,15 +393,39 @@ class OMEZarrWriterMP(ImageWriter):
             f"Expected frame shape {self._frame_shape}, got {frame.shape}"
         )
 
+        total_start = time.perf_counter()
+
         # Get a free slot (blocks if all slots are in use -> back-pressure)
+        t0 = time.perf_counter()
         slot = self._free_q.get()
+        wait_ms = (time.perf_counter() - t0) * 1000
 
         # Copy the frame into shared memory
+        t0 = time.perf_counter()
         np.copyto(self._ring[slot], frame)
-        # self._ring[slot] = frame
+        copy_ms = (time.perf_counter() - t0) * 1000
 
         # Tell writer process which slot to read
+        t0 = time.perf_counter()
         self._work_q.put(slot)
+        put_ms = (time.perf_counter() - t0) * 1000
+
+        total_ms = (time.perf_counter() - total_start) * 1000
+
+        if total_ms > 20:
+            logger.info(
+                "MP handoff: total=%.1f ms "
+                "free_slot_wait=%.1f ms "
+                "copy=%.1f ms "
+                "queue_put=%.1f ms "
+                "C_contiguous=%s strides=%s",
+                total_ms,
+                wait_ms,
+                copy_ms,
+                put_ms,
+                frame.flags['C_CONTIGUOUS'],
+                frame.strides
+            )
 
     def finalize(self, finalize_image: FinalizeImage) -> None:
         # Tell this tile's writer process to finish

--- a/mesoSPIM/src/plugins/ImageWriters/OmeZarrWriterMP.py
+++ b/mesoSPIM/src/plugins/ImageWriters/OmeZarrWriterMP.py
@@ -554,26 +554,3 @@ class OMEZarrWriterMP(ImageWriter):
 
             # clear the list so we don't double-join/unlink
         self._background_writers.clear()
-
-
-    # def _wait_for_background_writers(self):
-    #     """Wait for all tile writer processes to finish and clean shared memory."""
-    #     for proc, shm_name in self._background_writers:
-    #         try:
-    #             proc.join()
-    #         except Exception:
-    #             logger.exception("Error joining writer process")
-    #
-    #         # Now its shm can be safely unlinked
-    #         try:
-    #             shm = shared_memory.SharedMemory(name=shm_name)
-    #             shm.close()
-    #             shm.unlink()
-    #         except FileNotFoundError:
-    #             # Already cleaned or never created
-    #             pass
-    #         except Exception:
-    #             logger.exception("Error cleaning shared memory for %s", shm_name)
-    #
-    #     # clear the list so we don't double-join/unlink
-    #     self._background_writers.clear()

--- a/mesoSPIM/src/plugins/support_files/ImageWriters/OmeZarrWriterMP/omezarr_writer.py
+++ b/mesoSPIM/src/plugins/support_files/ImageWriters/OmeZarrWriterMP/omezarr_writer.py
@@ -434,9 +434,12 @@ class Live3DPyramidWriter:
         print("Live3DPyramidWriter: finalized.")
 
     def close_sync(self):
-        self.stop.set()
+
+        # Sentinel comes after all previously queued images.
+        # Therefore, the consumer drains every image before exiting.
         self.q.put(None)
         self.worker.join()
+        self.stop.set()
 
         with self.lock:
             # flush odd Z-pair tails at levels >= 1
@@ -520,7 +523,7 @@ class Live3DPyramidWriter:
     def _consume(self):
         while True:
             item = self.q.get()
-            if item is None or self.stop.is_set():
+            if item is None:
                 break
             self._ingest_raw(item)
 
@@ -920,6 +923,11 @@ def omezarr_writer_worker(
     from datetime import datetime
 
     lower_priority()
+
+    # child returns free ring slots through this queue.
+    # Don't let the multiprocessing Queue feeder prevent
+    # this process from exiting after acquisition is finished.
+    free_q.cancel_join_thread()
 
     def get_name_write_cache_dir(acq_path) -> Path | None:
         timestamp = datetime.now().strftime("%Y%m%d_%H%M%S")

--- a/mesoSPIM/src/plugins/support_files/ImageWriters/OmeZarrWriterMP/omezarr_writer.py
+++ b/mesoSPIM/src/plugins/support_files/ImageWriters/OmeZarrWriterMP/omezarr_writer.py
@@ -469,9 +469,9 @@ class Live3DPyramidWriter:
         return self.finalize_future
 
     def _finalize(self):
-        self.stop.set()
         self.q.put(None)
         self.worker.join()
+        self.stop.set()
 
         with self.lock:
             self._flush_pair_tails_all_the_way()


### PR DESCRIPTION
Addresses an issue where OME-Zarr multiprocessing writers could hang indefinitely during application shutdown, potentially causing the entire application to freeze. This was mostly seen at the end of a acquisition run where the GUI hangs after the final tile. This issue was exposed by changes made in PR #107.

*   **Improves shutdown reliability:** Introduces a timeout mechanism when waiting for child writer processes to exit, logging warnings if they remain active for extended periods. This prevents the parent process from blocking indefinitely during `finalize`.
*   **Ensures complete data processing:** Modifies the child writer's shutdown sequence to guarantee that all pending images in the queue are processed before the worker is signaled to stop, preventing data loss or premature termination.
*   **Prevents resource contention:** Disables `join_thread` on the `free_q` in child processes to ensure they don't prevent the main process from exiting if the child process terminates unexpectedly.
*   **Enhances diagnostic capabilities:** Adds detailed logging throughout the finalization and shutdown phases of both parent and child writers, providing better insight into the process state and aiding in debugging potential hangs.