### PR TITLE
Makes NI-DAQmx an Optional Dependency

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,8 @@
 ## Unreleased
+### Hardware Control & Support 🔧
+- Demo mode no longer requires the `nidaqmx` package: NI-DAQmx is imported through an optional shim, and `nidaqmx` has moved to an optional `ni` extra (`pip install -e ".[ni]"`). Both `requirements-*.txt` files still install it, so the documented install path is unchanged.
+- Configs selecting NI waveform generation, shutters or laser enable lines now fail at startup with a message naming the missing package or driver, instead of an import error or a `DaqNotFoundError` raised mid-acquisition.
+
 ### Bugfixes 🐛
 - PSF analysis tool: fixed bead detection finding 0 beads (or crashing) on beads elongated/wiggly in Z (e.g. stage-jitter artifacts): `keepBeads()` now keeps the brightest candidate among mutually-close peaks instead of discarding all of them, and 0 detected beads is reported in the UI instead of raising an uncaught error.
 - PSF analysis tool: beads sitting too close to a Z-stack edge for the configured fitting window are now excluded (previously a window that exactly touched the edge was silently accepted, giving an unreliable, baseline-biased axial fit).

--- a/docs/source/api/index.rst
+++ b/docs/source/api/index.rst
@@ -210,6 +210,11 @@ Shutters
 Utilities
 ---------
 
+.. automodule:: mesoSPIM.src.utils.ni_daqmx
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
 .. automodule:: mesoSPIM.src.utils.acquisitions
    :members:
    :undoc-members:

--- a/mesoSPIM/src/devices/lasers/mesoSPIM_LaserEnabler.py
+++ b/mesoSPIM/src/devices/lasers/mesoSPIM_LaserEnabler.py
@@ -2,8 +2,7 @@
 mesoSPIM Module for enabling single laser lines via NI-DAQmx
 """
 
-import nidaqmx
-from nidaqmx.constants import LineGrouping
+from ...utils.ni_daqmx import nidaqmx, require_nidaqmx, LineGrouping
 
 class mesoSPIM_LaserEnabler:
     ''' Class for interacting with the laser enable DO lines via NI-DAQmx
@@ -17,6 +16,7 @@ class mesoSPIM_LaserEnabler:
     '515 nm': 'PXI1Slot4/port0/line3'}
     '''
     def __init__(self, laserdict):
+        require_nidaqmx('NI laser enable line control')
         self.laserenablestate = 'None'
         self.laserdict = laserdict
 

--- a/mesoSPIM/src/devices/shutters/NI_Shutter.py
+++ b/mesoSPIM/src/devices/shutters/NI_Shutter.py
@@ -4,8 +4,7 @@ Author: Fabian Voigt
 #TODO
 """
 
-import nidaqmx
-from nidaqmx.constants import LineGrouping
+from ...utils.ni_daqmx import nidaqmx, require_nidaqmx, LineGrouping
 
 class NI_Shutter:
     """
@@ -19,6 +18,7 @@ class NI_Shutter:
     analog voltage for as long the device is not powered down.
     """
     def __init__(self, shutterline):
+        require_nidaqmx('NI shutter control')
         self.shutterline = shutterline
 
         # Make sure that the Shutter is closed upon initialization

--- a/mesoSPIM/src/mesoSPIM_Core.py
+++ b/mesoSPIM/src/mesoSPIM_Core.py
@@ -29,6 +29,7 @@ from .mesoSPIM_Camera import mesoSPIM_Camera
 
 from .devices.lasers.Demo_LaserEnabler import Demo_LaserEnabler
 from .devices.lasers.mesoSPIM_LaserEnabler import mesoSPIM_LaserEnabler
+from .utils.ni_daqmx import require_nidaqmx
 
 from .mesoSPIM_Serial import mesoSPIM_Serial
 from .mesoSPIM_WaveFormGenerator import mesoSPIM_WaveFormGenerator, mesoSPIM_DemoWaveFormGenerator
@@ -94,6 +95,14 @@ class mesoSPIM_Core(QtCore.QObject):
 
         self.state = self.parent.state # mesoSPIM_StateSingleton class
         self.state['state'] = 'init'
+
+        ''' If the config file asks for NI hardware, fail here rather than half-way through
+        device setup, when the camera and image writer threads are already running. The NI
+        device classes guard themselves as well, this is only about failing before side effects. '''
+        ni_selected = [key for key in ('waveformgeneration', 'shutter', 'laser')
+                       if getattr(self.cfg, key, None) in ('NI', 'cDAQ')]
+        if ni_selected:
+            require_nidaqmx(f"NI hardware selected in the config file ({', '.join(ni_selected)})")
 
         self.frame_queue = deque([])
         self.frame_queue_display = deque([], maxlen=1)    

--- a/mesoSPIM/src/mesoSPIM_WaveFormGenerator.py
+++ b/mesoSPIM/src/mesoSPIM_WaveFormGenerator.py
@@ -9,11 +9,9 @@ import time
 import logging
 logger = logging.getLogger(__name__)
 
-'''National Instruments Imports'''
-import nidaqmx
-from nidaqmx.constants import AcquisitionType, TaskMode
-from nidaqmx.constants import LineGrouping, DigitalWidthUnits
-from nidaqmx.types import CtrTime
+'''National Instruments Imports (optional: demo mode runs without them)'''
+from .utils.ni_daqmx import nidaqmx, require_nidaqmx
+from .utils.ni_daqmx import AcquisitionType, TaskMode, LineGrouping
 
 '''mesoSPIM imports'''
 from .utils.waveforms import single_pulse, tunable_lens_ramp, sawtooth, square
@@ -29,9 +27,12 @@ class mesoSPIM_WaveFormGenerator(QtCore.QObject):
 
     '''
     sig_update_gui_from_state = QtCore.pyqtSignal() # -> mesoSPIM_Core.sig_update_gui_from_state -> MainWindow.update_gui_from_state
+    requires_nidaqmx = True # the Demo subclass below sets this to False
 
     def __init__(self, parent):
         super().__init__()
+        if self.requires_nidaqmx:
+            require_nidaqmx('NI waveform generation')
         self.cfg = parent.cfg
         self.parent = parent # mesoSPIM_Core object
         self.state = self.parent.state # mesoSPIM_StateSingleton object
@@ -588,7 +589,11 @@ class mesoSPIM_WaveFormGenerator(QtCore.QObject):
 
 class mesoSPIM_DemoWaveFormGenerator(mesoSPIM_WaveFormGenerator):
     """Demo subclass of mesoSPIM_WaveFormGenerator class
+
+    Every method that touches a DAQmx task is overridden below, so this class
+    runs without the `nidaqmx` package and without the NI-DAQmx driver.
     """
+    requires_nidaqmx = False
 
     def __init__(self, parent):
         super().__init__(parent)

--- a/mesoSPIM/src/utils/ni_daqmx.py
+++ b/mesoSPIM/src/utils/ni_daqmx.py
@@ -1,0 +1,74 @@
+'''
+ni_daqmx.py
+========================================
+
+Optional-import shim for NI-DAQmx. Modules that talk to NI cards import the
+package through here, so a missing installation does not break startup: the NI
+classes raise a readable error when instantiated, and Demo mode is unaffected.
+
+The package and the driver install separately. `pip install nidaqmx` gives only
+the Python wrapper, so both are checked.
+'''
+
+import logging
+
+logger = logging.getLogger(__name__)
+
+try:
+    import nidaqmx
+    import nidaqmx.system  # the driver check below needs this submodule, do not rely on Task pulling it in
+    from nidaqmx.constants import AcquisitionType, LineGrouping, TaskMode
+    NIDAQMX_AVAILABLE = True
+except ImportError as error:
+    nidaqmx = None
+    AcquisitionType = LineGrouping = TaskMode = None
+    NIDAQMX_AVAILABLE = False
+    logger.info(f"The 'nidaqmx' package is not available ({error}). "
+                f"NI hardware cannot be used, demo mode is unaffected.")
+
+'''The driver cannot appear while the application is running, so a successful check is cached.'''
+_driver_checked = False
+
+
+def require_nidaqmx(device):
+    """Raise if a config file asks for NI hardware that this machine cannot drive.
+
+    Checks the `nidaqmx` package and the NI-DAQmx driver it wraps, which are
+    installed separately and can each be missing on their own.
+
+    Args:
+        device (str): what the caller was setting up, used in the error message.
+
+    Raises:
+        ImportError: if the package is not installed, or if it is installed but
+            the NI-DAQmx driver it needs is not present.
+    """
+    if not NIDAQMX_AVAILABLE:
+        raise ImportError(f"{device} requires the 'nidaqmx' package, which is not installed. "
+                          f"Install it with 'pip install nidaqmx' together with the NI-DAQmx driver, "
+                          f"or select the 'Demo' options in the configuration file.")
+    _require_driver(device)
+
+
+def _require_driver(device):
+    """Raise if the `nidaqmx` package is installed but the NI-DAQmx driver is not.
+
+    Reading the driver version is the cheapest call that makes `nidaqmx` load the
+    DAQmx library, which it otherwise defers until the first task is created.
+    """
+    global _driver_checked
+    if _driver_checked:
+        return
+    try:
+        version = nidaqmx.system.System.local().driver_version
+    except Exception as error:
+        '''nidaqmx raises DaqNotFoundError for this on Windows, but the failure mode of
+        loading the library differs between platforms and package versions, so anything
+        that goes wrong here is reported as the missing driver it almost certainly is.'''
+        raise ImportError(f"{device} requires the NI-DAQmx driver, which could not be loaded ({error}). "
+                          f"The 'nidaqmx' package is installed, but it is only a wrapper: install the "
+                          f"NI-DAQmx driver from National Instruments as well, or select the 'Demo' "
+                          f"options in the configuration file.") from error
+    _driver_checked = True
+    logger.info(f"NI-DAQmx driver version {version.major_version}.{version.minor_version}."
+                f"{version.update_version} found.")

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -18,7 +18,6 @@ dependencies = [
     "scipy==1.14.1",
     "PyQt5==5.15.11",
     "PyQt5-sip==12.15.0",
-    "nidaqmx==1.0.1",
     "indexed==1.3.0",
     "pipython==2.10.2.1",
     "pyserial==3.5",
@@ -30,6 +29,12 @@ dependencies = [
     "future==1.0.0",
     "matplotlib==3.9.2"
 ]
+
+[project.optional-dependencies]
+# NI-DAQmx is only needed by setups that drive National Instruments hardware, i.e. a config
+# file with 'waveformgeneration', 'shutter' or 'laser' set to 'NI' or 'cDAQ'. Demo mode and
+# the docs build run without it. The requirements-*.txt files still install it directly.
+ni = ["nidaqmx==1.0.1"]
 
 [project.urls]
 "Homepage" = "http://mesospim.org"


### PR DESCRIPTION
Hi, I'm a programmer at Applied Scientific Instrumentation.

This will be used to implement additional support for the ASI Tiger Controller, the first step is to make the `nidaqmx` package optional.

Please let me know if you'd like me to change anything (I can do the work) or feel free to change it to your liking.

*Details below, drafted with AI assistance and verified by me:*

## What

Demo mode drives no National Instruments hardware, but `nidaqmx` was imported at module level in the waveform generator, the NI shutter and the laser enabler, so the application could not start at all without the package installed. This routes those imports through a single shim, `mesoSPIM/src/utils/ni_daqmx.py`, and moves `nidaqmx` to an optional `ni` extra.

Nothing changes for a microscope that drives NI hardware. Both `requirements-clean-python.txt` and `requirements-conda-mamba.txt` still install `nidaqmx` directly, so the documented install path is untouched.

## Why

- Demo mode, and any development or CI work that only needs it, no longer requires the `nidaqmx` package to be installed.
- The failure mode when NI *is* selected but unavailable is now a sentence explaining what to install, instead of a `ModuleNotFoundError` on an import line, or a `DaqNotFoundError` thrown from deep inside task creation.

## How

**The shim** try/except-imports `nidaqmx` and re-exports it along with `AcquisitionType`, `LineGrouping` and `TaskMode`, plus a `NIDAQMX_AVAILABLE` flag and a `require_nidaqmx(device)` guard. When the package is missing, module import still succeeds and an INFO line is logged; failure is deferred to the point where an NI device is actually constructed.

**Guards** are called at the top of `NI_Shutter.__init__`, `mesoSPIM_LaserEnabler.__init__` and `mesoSPIM_WaveFormGenerator.__init__`. `mesoSPIM_DemoWaveFormGenerator` subclasses the latter and sets `requires_nidaqmx = False`, since it overrides every method that touches a DAQmx task.

**`mesoSPIM_Core`** additionally checks once, early in `__init__`, whether the config selects `'NI'` or `'cDAQ'` for `waveformgeneration`, `shutter` or `laser`, mirroring its own dispatch further down the same file. This fails before the camera and image writer threads are started, rather than half-way through device setup. The per-class guards are kept as the authoritative check, since they sit at the actual point of use.

**The driver is checked too.** `nidaqmx` and the NI-DAQmx driver install separately: `pip install nidaqmx` gives only the Python wrapper, which imports cleanly on a machine that has never seen an NI card, and the driver is not looked for until the first call into the DAQmx library. `require_nidaqmx` probes it via `System.local().driver_version`, a cheap call that forces the DAQmx library to load, caches success, and reports a missing driver at device setup rather than mid-acquisition. The original `DaqNotFoundError` is chained as `__cause__`.

## Testing

In a fresh virtualenv with `nidaqmx` genuinely absent (`pip install -e .` only):

- Demo mode starts clean, and running an 11-plane acquisition writes the TIFF, MAX projection and metadata, completes `end_acquisition()` and returns the state to `idle`. No `AttributeError`/`NoneType` anywhere, and the only `nidaqmx` mention in the log is the shim's own INFO line. This covers the task-lifecycle methods that startup alone never reaches.
- All four NI-touching modules import successfully; constructing any NI device raises `ImportError` naming the package and the install command; the Core guard fires on an NI config and lets a Demo config through.
- `sphinx-build` over `docs/source` succeeds, matching what `docs.yml` does.

On a machine with the package but no driver, the guard reports the missing *driver* rather than the package, at device construction, with `DaqNotFoundError` chained. The driver-present path was exercised with a stubbed `DriverVersion` to confirm the version-logging line; it has not run against real NI hardware.

`pip install -e .` resolves 35 packages with no `nidaqmx` anywhere in the transitive graph; `pip install -e ".[ni]"` adds it plus its dependencies.
